### PR TITLE
feat: [FE] 구글캘린더 일정 추가 기능 구현

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -385,3 +385,98 @@
     }
 }
 
+.modal-overlay {
+    display: none; /* 기본적으로 숨김 */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 10000; /* 다른 요소들보다 위에 보이도록 높은 값 설정 */
+    justify-content: center;
+    align-items: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+/* JS에서 visible 클래스가 추가되면 보이게 됩니다 */
+.modal-overlay.visible {
+    display: flex;
+    opacity: 1;
+}
+
+.modal-container {
+    background-color: #fff;
+    border-radius: 16px;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.2);
+    width: 90%;
+    max-width: 400px;
+    overflow: hidden;
+    transform: translateY(20px);
+    transition: transform 0.3s ease;
+}
+
+.modal-overlay.visible .modal-container {
+    transform: translateY(0);
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 24px;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.modal-header h3 {
+    margin: 0;
+    font-size: 18px;
+    font-weight: 600;
+    color: #111827;
+}
+
+.close-btn {
+    background: none;
+    border: none;
+    font-size: 24px;
+    color: #9ca3af;
+    cursor: pointer;
+    padding: 4px;
+    line-height: 1;
+}
+
+.close-btn:hover {
+    color: #4b5563;
+}
+
+.modal-body {
+    padding: 32px 24px;
+    text-align: center;
+    font-size: 16px;
+    color: #374151;
+    line-height: 1.5;
+}
+
+.modal-footer {
+    padding: 20px 24px;
+    background-color: #f9fafb;
+    border-top: 1px solid #f3f4f6;
+}
+
+.google-btn {
+    width: 100%;
+    padding: 12px;
+    background-color: #4285F4;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.google-btn:hover {
+    background-color: #357abd;
+}


### PR DESCRIPTION
## **구현 기능 요약**
1. 홈 대시보드 UI 스타일 수정 및 데이터 필터링 로직 개선
---

## **개발 내역 상세**

1. Home 화면 To-Do 리스트 UI 수정

2. home.css 내 To-Do 관련 스타일(.todo-item, .todo-checkbox 등)을 수정하여 체크박스 깨짐 현상 해결 및 디자인 적용

3. '다가오는 중요 회의' 카드 필터링 수정

4. home.js의 renderImportantMeetings 함수에서 TASK(할 일) 타입이 제외되도록 필터 조건 변경

5. e.type === 'meeting' 조건을 추가하여 순수 회의 일정만 표시되도록 개선
---

## **검증 방법**

1. 캘린더 페이지에서 새로운 '할 일(To-Do)'을 등록한다.
 
2. 홈 화면으로 이동하여 'To-Do' 카드에 등록한 할 일이 정상적인 스타일로 표시되는지 확인한다.
 
3. '다가오는 중요 회의' 카드에 '할 일'이 노출되지 않고, '중요' 표시된 '회의'만 노출되는지 확인한다.

---

## **추가 개선 / TODO**

- [ ] 캘린더에서 일정 추가/수정 시 홈 화면 실시간 데이터 동기화(백그라운드 갱신) 확인
 
- [ ] 각 카드별 데이터가 없을 경우 보여줄 Empty State UI 디자인 개선
