### PR TITLE
feat: [FE] 회원가입 부분 예외처리 수정 및 로그인 회원가입 성공,에러 알림 분리

### DIFF
--- a/login.html
+++ b/login.html
@@ -118,8 +118,8 @@
                 <div class="forms-container">
                     <!-- 로그인 폼 -->
                     <form id="signinForm" class="form-section active">
-                        <div id="errorAlert" class="alert error-alert"></div>
-                        <div id="successAlert" class="alert success-alert"></div>
+                            <div id="signinErrorAlert" class="alert error-alert"></div>
+                            <div id="signinSuccessAlert" class="alert success-alert"></div>
                         <div class="input-group">
                             <label>Email</label>
                             <div class="input-wrapper">
@@ -180,11 +180,14 @@
 
                     <!-- 회원가입 폼 -->
                     <form id="signupForm" class="form-section">
+                            <div id="signupErrorAlert" class="alert error-alert"></div>
+                            <div id="signupSuccessAlert" class="alert success-alert"></div>
                         <div class="input-group">
                             <label>이름</label>
                             <div class="input-wrapper">
                                 <input type="text" id="signup-name" placeholder="Your name" required>
                             </div>
+                            <div id="signupNameErrorAlert" class="alert error-alert"></div>
                         </div>
 
                         <div class="input-group">
@@ -192,6 +195,7 @@
                             <div class="input-wrapper">
                                 <input type="email" id="signup-email" placeholder="your@email.com" required>
                             </div>
+                            <div id="signupEmailErrorAlert" class="alert error-alert"></div>
                         </div>
 
                         <div class="input-group">
@@ -205,6 +209,7 @@
                                     </svg>
                                 </span>
                             </div>
+                            <div id="signupPasswordErrorAlert" class="alert error-alert"></div>
                         </div>
 
                         <div class="input-group">
@@ -218,6 +223,7 @@
                                     </svg>
                                 </span>
                             </div>
+                            <div id="signupConfirmErrorAlert" class="alert error-alert"></div>
                         </div>
 
                         <div class="form-options">
@@ -225,6 +231,7 @@
                                 <input type="checkbox" id="terms" required>
                                 <span>이용약관 및 개인정보처리방침 동의</span>
                             </label>
+                            <div id="termsErrorAlert" class="alert error-alert"></div>
                         </div>
 
                         <div class="form-bottom">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -343,8 +343,8 @@ apiClient.interceptors.response.use(
 // 커스텀 예외 처리 함수 
 // =====================================
 window.CustomExceptionHandlers = {
-    handleGoogleOAuthException(errorData) {
-        showAlert(errorData.message || "Google OAuth 인증 오류가 발생했습니다.", 'error');
+    handleGoogleOAuthException(errorData, context) {
+        showAlert(errorData.message || "Google OAuth 인증 오류가 발생했습니다.", 'error', context);
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
         localStorage.removeItem('userInfo');
@@ -354,101 +354,114 @@ window.CustomExceptionHandlers = {
             window.location.href = "/login.html";
         }, 2000);
     },
-    handleResourceNotFoundException(errorData) {
-        showAlert(errorData.message || "요청한 리소스를 찾을 수 없습니다.", 'error');
+    handleResourceNotFoundException(errorData, context) {
+        showAlert(errorData.message || "요청한 리소스를 찾을 수 없습니다.", 'error', context);
     },
-    handleAccessDeniedException(errorData) {
-        showAlert(errorData.message || "접근 권한이 없습니다.", 'error');
+    handleAccessDeniedException(errorData, context) {
+        showAlert(errorData.message || "접근 권한이 없습니다.", 'error', context);
     },
-    handleBadRequestException(errorData) {
-        showEmailError(errorData.message || "잘못된 요청입니다.");
+    handleBadRequestException(errorData, context) {
+        // signup 쪽이면 개별 필드 에러로, 아니면 공통 알림으로
+        if (context === 'signup') {
+            showSignupEmailError(errorData.message || "잘못된 요청입니다.");
+        } else {
+            showAlert(errorData.message || "잘못된 요청입니다.", 'error', context);
+        }
     },
-    handleUserNotFoundException(errorData) {
-        showEmailError(errorData.message || "존재하지 않는 아이디입니다.");
+    handleUserNotFoundException(errorData, context) {
+        if (context === 'signup') {
+            showSignupEmailError(errorData.message || "존재하지 않는 아이디입니다.");
+        } else {
+            showEmailError(errorData.message || "존재하지 않는 아이디입니다.");
+        }
     },
-    handleUserAlreadyExistsException(errorData) {
-        showAlert(errorData.message || "이미 존재하는 사용자입니다.", 'error');
+    handleUserAlreadyExistsException(errorData, context) {
+        showAlert(errorData.message || "이미 존재하는 사용자입니다.", 'error', context);
     },
-    handleInvalidPasswordException(errorData) {
-        showPasswordError(errorData.message || "비밀번호가 올바르지 않습니다.");
+    handleInvalidPasswordException(errorData, context) {
+        if (context === 'signup') {
+            showSignupPasswordError(errorData.message || "비밀번호가 올바르지 않습니다.");
+        } else {
+            showPasswordError(errorData.message || "비밀번호가 올바르지 않습니다.");
+        }
     },
-    handleInactiveUserException(errorData) {
-        showAlert(errorData.message || "비활성화된 사용자입니다. 문의해 주세요.", 'error');
+    handleInactiveUserException(errorData, context) {
+        showAlert(errorData.message || "비활성화된 사용자입니다. 문의해 주세요.", 'error', context);
     },
-    handleUserRoleAccessDeniedException(errorData) {
-        showAlert(errorData.message || "접근 권한이 없습니다.", 'error');
+    handleUserRoleAccessDeniedException(errorData, context) {
+        showAlert(errorData.message || "접근 권한이 없습니다.", 'error', context);
     },
-    handleSocialUserSaveException(errorData) {
-        showAlert(errorData.message || "소셜 사용자 저장에 실패했습니다.", 'error');
+    handleSocialUserSaveException(errorData, context) {
+        showAlert(errorData.message || "소셜 사용자 저장에 실패했습니다.", 'error', context);
     },
-    handleRefreshTokenException(errorData) {
-        showAlert(errorData.message || "리프레시 토큰 오류입니다. 재로그인 해주세요.", 'error');
+    handleRefreshTokenException(errorData, context) {
+        showAlert(errorData.message || "리프레시 토큰 오류입니다. 재로그인 해주세요.", 'error', context);
     },
-    handleSocialUserInfoException(errorData) {
-        showAlert(errorData.message || "소셜 사용자 정보 처리 중 오류가 발생했습니다.", 'error');
+    handleSocialUserInfoException(errorData, context) {
+        showAlert(errorData.message || "소셜 사용자 정보 처리 중 오류가 발생했습니다.", 'error', context);
     },
-    handleInvalidJwtTokenException(errorData) {
-        showAlert(errorData.message || "유효하지 않은 토큰입니다. 재인증이 필요합니다.", 'error');
+    handleInvalidJwtTokenException(errorData, context) {
+        showAlert(errorData.message || "유효하지 않은 토큰입니다. 재인증이 필요합니다.", 'error', context);
     },
-    handleOAuthUserNotFoundException(errorData) {
-        showAlert(errorData.message || "OAuth 사용자 정보를 찾을 수 없습니다.", 'error');
+    handleOAuthUserNotFoundException(errorData, context) {
+        showAlert(errorData.message || "OAuth 사용자 정보를 찾을 수 없습니다.", 'error', context);
     },
-    handleTermsNotAcceptedException(errorData) {
-        showAlert(errorData.message || "약관에 동의해야 가입할 수 있습니다.", 'error');
+    handleTermsNotAcceptedException(errorData, context) {
+        showTermsError(errorData.message || "약관에 동의해야 가입할 수 있습니다.");
     },
-    handleErrorResponse(status, errorData) {
+    handleErrorResponse(status, errorData, context) {
         switch (status) {
             case 400:
                 if (errorData.error === "약관 미동의") {
-                    this.handleTermsNotAcceptedException(errorData);
+                    this.handleTermsNotAcceptedException(errorData, context);
                 } else if (errorData.error === "이미 존재하는 사용자") {
-                    this.handleUserAlreadyExistsException(errorData);
+                    this.handleUserAlreadyExistsException(errorData, context);
                 } else {
-                    this.handleBadRequestException(errorData);
+                    this.handleBadRequestException(errorData, context);
                 }
                 break;
             case 401:
                 if (errorData.errorCode === "GOOGLE_REAUTH_REQUIRED") {
-                    this.handleGoogleOAuthException(errorData);
+                    this.handleGoogleOAuthException(errorData, context);
                 } else if (errorData.error === "비밀번호 오류") {
-                    this.handleInvalidPasswordException(errorData);
+                    this.handleInvalidPasswordException(errorData, context);
                 } else if (errorData.error === "리프레시 토큰 오류") {
-                    this.handleRefreshTokenException(errorData);
+                    this.handleRefreshTokenException(errorData, context);
                 } else if (errorData.error === "유효하지 않은 토큰") {
-                    this.handleInvalidJwtTokenException(errorData);
+                    this.handleInvalidJwtTokenException(errorData, context);
                 } else {
-                    showAlert(errorData.message || "인증이 필요합니다.", 'error');
+                    showAlert(errorData.message || "인증이 필요합니다.", 'error', context);
                 }
                 break;
             case 403:
                 if (errorData.error === "권한 없음") {
-                    this.handleUserRoleAccessDeniedException(errorData);
+                    this.handleUserRoleAccessDeniedException(errorData, context);
                 } else if (errorData.error === "비활성 사용자") {
-                    this.handleInactiveUserException(errorData);
+                    this.handleInactiveUserException(errorData, context);
                 } else if (errorData.error === "소셜 사용자 저장 실패") {
-                    this.handleSocialUserSaveException(errorData);
+                    this.handleSocialUserSaveException(errorData, context);
                 } else {
-                    this.handleAccessDeniedException(errorData);
+                    this.handleAccessDeniedException(errorData, context);
                 }
                 break;
             case 404:
                 if (errorData.error === "사용자 없음") {
-                    this.handleUserNotFoundException(errorData);
+                    this.handleUserNotFoundException(errorData, context);
                 } else if (errorData.error === "OAuth 사용자 없음") {
-                    this.handleOAuthUserNotFoundException(errorData);
+                    this.handleOAuthUserNotFoundException(errorData, context);
                 } else {
-                    this.handleResourceNotFoundException(errorData);
+                    this.handleResourceNotFoundException(errorData, context);
                 }
                 break;
             case 500:
                 if (errorData.error === "소셜 사용자 정보 오류") {
-                    this.handleSocialUserInfoException(errorData);
+                    this.handleSocialUserInfoException(errorData, context);
                 } else {
-                    showAlert("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", 'error');
+                    showAlert("서버 내부 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", 'error', context);
                 }
                 break;
             default:
-                showAlert(errorData.message || "알 수 없는 오류가 발생했습니다.", 'error');
+                showAlert(errorData.message || "알 수 없는 오류가 발생했습니다.", 'error', context);
                 break;
         }
     }

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -88,26 +88,43 @@ function showPasswordError(message) {
 /* ===============================
     팝업 알림 함수 (디버깅 로그 포함)
 =================================*/
-function showAlert(message, type) {
-    console.log('showAlert 호출:', message, type);
-    const errorAlert = document.getElementById('errorAlert');
-    const successAlert = document.getElementById('successAlert');
+function showAlert(message, type, context) {
+    let errorAlert, successAlert;
+
+    if (context === 'signup') {
+        errorAlert = document.getElementById('signupErrorAlert');
+        successAlert = document.getElementById('signupSuccessAlert');
+    } else {
+        // 기본값은 로그인폼
+        errorAlert = document.getElementById('signinErrorAlert');
+        successAlert = document.getElementById('signinSuccessAlert');
+    }
+
     if (!errorAlert || !successAlert) {
         console.warn('알림 영역 DOM 요소를 찾을 수 없습니다.');
         return;
     }
-    hideAlerts();
-    clearFieldErrors();
+    hideAlerts(context);
 
-    const alert = type === 'error' ? errorAlert : successAlert;
-    alert.textContent = message;
-    alert.classList.add('show');
-    setTimeout(() => hideAlerts(), 3000); 
+    const alertDiv = type === 'error' ? errorAlert : successAlert;
+    alertDiv.textContent = message;
+    alertDiv.classList.add('show');
+    setTimeout(() => {
+        alertDiv.classList.remove('show');
+        alertDiv.textContent = '';
+    }, 3000);
 }
 
-function hideAlerts() {
-    const errorAlert = document.getElementById('errorAlert');
-    const successAlert = document.getElementById('successAlert');
+
+function hideAlerts(context) {
+    let errorAlert, successAlert;
+    if (context === 'signup') {
+        errorAlert = document.getElementById('signupErrorAlert');
+        successAlert = document.getElementById('signupSuccessAlert');
+    } else {
+        errorAlert = document.getElementById('signinErrorAlert');
+        successAlert = document.getElementById('signinSuccessAlert');
+    }
     if (errorAlert) errorAlert.classList.remove('show');
     if (successAlert) successAlert.classList.remove('show');
 }
@@ -159,12 +176,80 @@ signinForm.addEventListener('submit', async function(e) {
         window.CustomExceptionHandlers.handleErrorResponse(null, { message: '네트워크 오류 또는 서버 오류: ' + error.message });
     }
 });
+// 각 회원가입용 에러 함수, 초기화 함수 추가
+const signupNameErrorAlert = document.getElementById('signupNameErrorAlert');
+const signupEmailErrorAlert = document.getElementById('signupEmailErrorAlert');
+const signupPasswordErrorAlert = document.getElementById('signupPasswordErrorAlert');
+const signupConfirmErrorAlert = document.getElementById('signupConfirmErrorAlert');
+const termsErrorAlert = document.getElementById('termsErrorAlert');
 
+// 전체 에러 초기화
+function clearSignupFieldErrors() {
+    signupNameErrorAlert.textContent = '';
+    signupNameErrorAlert.classList.remove('show');
+    signupEmailErrorAlert.textContent = '';
+    signupEmailErrorAlert.classList.remove('show');
+    signupPasswordErrorAlert.textContent = '';
+    signupPasswordErrorAlert.classList.remove('show');
+    signupConfirmErrorAlert.textContent = '';
+    signupConfirmErrorAlert.classList.remove('show');
+    if(termsErrorAlert) {
+    termsErrorAlert.textContent = '';
+    termsErrorAlert.classList.remove('show');
+    }
+}
+
+// 각 필드 에러 표시 함수
+function showSignupNameError(msg) {
+    clearSignupFieldErrors();
+    signupNameErrorAlert.textContent = msg;
+    signupNameErrorAlert.classList.add('show');
+    setTimeout(() => {
+        signupNameErrorAlert.classList.remove('show');
+        signupNameErrorAlert.textContent = '';
+    }, 2000);
+}
+function showSignupEmailError(msg) {
+    clearSignupFieldErrors();
+    signupEmailErrorAlert.textContent = msg;
+    signupEmailErrorAlert.classList.add('show');
+    setTimeout(() => {
+        signupEmailErrorAlert.classList.remove('show');
+        signupEmailErrorAlert.textContent = '';
+    }, 2000);
+}
+function showSignupPasswordError(msg) {
+    clearSignupFieldErrors();
+    signupPasswordErrorAlert.textContent = msg;
+    signupPasswordErrorAlert.classList.add('show');
+    setTimeout(() => {
+        signupPasswordErrorAlert.classList.remove('show');
+        signupPasswordErrorAlert.textContent = '';
+    }, 2000);
+}
+function showSignupConfirmError(msg) {
+    clearSignupFieldErrors();
+    signupConfirmErrorAlert.textContent = msg;
+    signupConfirmErrorAlert.classList.add('show');
+    setTimeout(() => {
+        signupConfirmErrorAlert.classList.remove('show');
+        signupConfirmErrorAlert.textContent = '';
+    }, 2000);
+}
+function showTermsError(msg) {
+    termsErrorAlert.textContent = msg;
+    termsErrorAlert.classList.add('show');
+    setTimeout(() => {
+        termsErrorAlert.classList.remove('show');
+        termsErrorAlert.textContent = '';
+    }, 2000);
+}
 /* ===============================
     회원가입 폼 제출 처리 (디버깅 포함)
 =================================*/
 signupForm.addEventListener('submit', async function(e) {
     e.preventDefault();
+    clearSignupFieldErrors();
 
     const name = document.getElementById('signup-name').value.trim();
     const email = document.getElementById('signup-email').value.trim();
@@ -172,29 +257,41 @@ signupForm.addEventListener('submit', async function(e) {
     const confirm = document.getElementById('signup-confirm').value;
     const terms = document.getElementById('terms').checked;
 
-    if (!name || !email || !password || !confirm) {
-        window.CustomExceptionHandlers.handleErrorResponse(null, { message: '모든 필드를 입력해주세요.' });
+    if (!name) {
+        showSignupNameError('이름을 입력해주세요.');
         return;
     }
     if (name.length < 2) {
-        window.CustomExceptionHandlers.handleErrorResponse(null, { message: '이름은 2자 이상 입력해주세요.' });
+        showSignupNameError('이름은 2자 이상 입력해주세요.');
+        return;
+    }
+    if (!email) {
+        showSignupEmailError('이메일을 입력해주세요.');
         return;
     }
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-        window.CustomExceptionHandlers.handleErrorResponse(null, { message: '올바른 이메일 형식을 입력해주세요.' });
+        showSignupEmailError('올바른 이메일 형식을 입력해주세요.');
+        return;
+    }
+    if (!password) {
+        showSignupPasswordError('비밀번호를 입력해주세요.');
         return;
     }
     if (password.length < 12) {
-        window.CustomExceptionHandlers.handleErrorResponse(null, { message: '비밀번호는 12자 이상 입력해주세요.' });
+        showSignupPasswordError('비밀번호는 12자 이상 입력해주세요.');
+        return;
+    }
+    if (!confirm) {
+        showSignupConfirmError('비밀번호 확인을 입력해주세요.');
         return;
     }
     if (password !== confirm) {
-        window.CustomExceptionHandlers.handleErrorResponse(null, { message: '비밀번호가 일치하지 않습니다.' });
+        showSignupConfirmError('비밀번호가 일치하지 않습니다.');
         return;
     }
     if (!terms) {
-        window.CustomExceptionHandlers.handleErrorResponse(null, { message: '약관에 동의해주세요.' });
+        showTermsError('이용약관에 동의해주세요.');
         return;
     }
 
@@ -206,14 +303,14 @@ signupForm.addEventListener('submit', async function(e) {
         });
         const data = await response.json();
         if (response.ok && data.success) {
-            showAlert('회원가입 성공! 로그인 페이지로 이동합니다.', 'success');
+            showAlert('회원가입 성공! 로그인 페이지로 이동합니다.', 'success', 'signup');
             setTimeout(() => {
                 signinTab.click();
                 signupForm.reset();
             }, 2000);
         } else {
             console.log('handleErrorResponse 호출됨', response.status, data);
-            window.CustomExceptionHandlers.handleErrorResponse(response.status, data);
+            window.CustomExceptionHandlers.handleErrorResponse(response.status, data, 'signup');
         }
     } catch (error) {
         console.error('서버 오류:', error);


### PR DESCRIPTION
## **구현 기능 요약**

* 회원 가입 부분 예외처리 수정
* 로그인 및 회원 가입 성공, 에러 알림 분리

---

## **개발 내역 상세**

* 회원 가입 부분 이름 길이, 비밀번호 길이, 비밀번호 확인, 이메일 사용 유무, 약관 동의 확인 예외 처리 스타일 적용
* SuccessAlert, ErrorAlert 세분화하여 로그인, 회원 가입 시 성공, 에러 알림 분리
* 로그인 성공 알림 (signinErrorAlert, signinSuccessAlert) 분리
* 회원 가입 성공 알림, 에러 알림 (signupErrorAlert, signupSuccessAlert) 분리
---

## **검증 방법**
*  이름 한 글자로 회원 가입 시도 후 에러 메시지 확인, 이미 사용 중인 이메일로 회원 가입 시도 후 에러 메시지 확인
*  비밀번호 1글자로 회원 가입 시도 후 에러 메시지 확인, 입력한 비밀번호와 다른 비밀번호 입력 후 에러 메시지 확인
*  회원 가입 성공 시 메시지 확인, 회원 가입 실패 시 메시지 확인
*  로그인 성공 시 메시지 확인, 로그인 과정 중 실패 시 에러 메시지 확인
---

## **추가 개선 / TODO**
* 다음 작업 : login.js 뿐만 아니라 다른 js 에서 커스텀 예외 불러서 사용하도록 수정

