### PR TITLE
feat: [FE] 캘린더 UI 및 홈 UI 리스트 개선 작업

### DIFF
--- a/static/css/home.css
+++ b/static/css/home.css
@@ -366,7 +366,7 @@
 }
 
 /* ============================================
-   반응형
+반응형
    ============================================ */
 
 @media (max-width: 1024px) {
@@ -468,7 +468,7 @@
 .google-btn {
     width: 100%;
     padding: 12px;
-    background-color: #4285F4;
+    background-color: #8E44AD;
     color: white;
     border: none;
     border-radius: 8px;
@@ -518,58 +518,89 @@
   background: #7d3c98;
 }
 
-/* ===============================
-    Google 연동 모달 스타일 (추가)
-=================================*/
-.modal-overlay {
-  display: none; /* 기본 숨김 */
-  position: fixed;
-  z-index: 1000;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  overflow: auto;
-  background-color: rgba(0,0,0,0.5);
-  justify-content: center;
-  align-items: center;
-  opacity: 0;
-  transition: opacity 0.2s ease;
+.google-link-banner {
+    position: fixed; /* position이 fixed여야 transform이 올바르게 동작합니다 */
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+    background-color: #fff8e1;
+    border-bottom: 1px solid #ffecb3;
+    padding: 16px 24px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
+    opacity: 0;
+    transform: translateY(-100%); 
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.google-link-banner .banner-actions {
+    display: flex;
+    align-items: center; /* (추가) 세로 중앙 정렬 */
+    gap: 12px;
 }
 
-.modal-overlay.visible {
-  display: flex;
-  opacity: 1;
+.google-link-banner.visible {
+    opacity: 1; /* 1. 보이는 상태: 불투명하게 */
+    transform: translateY(0); /* 2. 보이는 상태: 제자리로 */
 }
 
-.modal-content {
-  background-color: #fff;
-  padding: 24px;
-  border-radius: 8px;
-  width: 90%;
-  max-width: 450px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-  text-align: center;
-  position: relative;
+.google-empty-state {
+    /* * (중요) 부모(.deadline-list, .todo-list)가 
+     * flex: 1 또는 flex-grow: 1을 가지고 있어
+     * 이 컨테이너가 남은 빈 공간을 모두 차지합니다.
+     */
+    height: 100%;
+    
+    /* 내용물(아이콘, 텍스트, 버튼)을 세로로 배치 */
+    display: flex;
+    flex-direction: column;
+
+    /* 내용물을 수직/수평 중앙에 정렬 */
+    justify-content: center;
+    align-items: center;
+
+    padding: 20px;
+    text-align: center;
 }
 
-.modal-close-btn {
-  position: absolute;
-  top: 10px;
-  right: 15px;
-  background: none;
-  border: none;
-  font-size: 24px;
-  color: #999;
-  cursor: pointer;
+/* 아이콘 스타일 (이모지 사용) */
+.empty-state-icon {
+    font-size: 36px; /* 이모지 아이콘 크기 */
+    margin-bottom: 16px;
+    opacity: 0.8;
 }
 
-.modal-content h3 {
-  margin-top: 0;
-  margin-bottom: 12px;
+/* 안내 텍스트 스타일 */
+.empty-state-text {
+    font-size: 14px;
+    color: #6b7280; /* 너무 진하지 않은 회색 */
+    line-height: 1.6;
+    margin-bottom: 24px;
+    margin-top: 0;
 }
 
-.modal-content p {
-  margin-bottom: 24px;
-  color: #555;
+/* 연동 버튼 스타일 */
+.empty-state-button {
+    /* 기존 .admin-btn-small 스타일과 유사하게 맞춤 */
+    height: 34px;
+    padding: 0 14px;
+    font-size: 15px;
+    font-weight: 600;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    border-radius: 8px;
+    background: #8E44AD; /* 대시보드 메인 보라색 */
+    color: #fff;
+    border: none;
+    cursor: pointer;
+    transition: background 0.16s;
+}
+
+.empty-state-button:hover {
+    background: #7d3c98; /* 보라색 hover */
 }

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -4,8 +4,8 @@
 
 document.addEventListener("DOMContentLoaded", () => {
     loadCommonComponents();
-    loadCurrentUserInHome();
     initHomeData();
+    loadRecentMeetings();
 });
 
 // =========================================
@@ -19,6 +19,7 @@ function loadCommonComponents() {
             if (container) {
                 container.innerHTML = html;
                 initChatbotEventListeners();
+                loadCurrentUser();
             }
         });
 
@@ -29,7 +30,7 @@ function loadCommonComponents() {
             if (sidebar) {
                 sidebar.innerHTML = html;
                 activateCurrentNav(sidebar);
-                loadCurrentUserInHome();
+                loadCurrentUser();
             }
         });
 }
@@ -51,30 +52,6 @@ function activateCurrentNav(sidebar) {
     sidebar.querySelectorAll(".nav-menu a").forEach(item => {
         item.classList.toggle("active", item.getAttribute("href") === currentPage);
     });
-}
-
-// =========================================
-//  2. 사용자 정보 로드
-// =========================================
-async function loadCurrentUserInHome() {
-    try {
-        const response = await fetch('http://localhost:8080/api/auth/me', { credentials: 'include' });
-        if (response.ok) {
-            const user = await response.json();
-            displayUserNameInHome(user);
-        }
-    } catch (error) {
-        console.error('사용자 정보 로드 실패:', error);
-    }
-}
-
-function displayUserNameInHome(user) {
-    const name = (user && user.name) || (user && user.email) || '사용자';
-    const headerName = document.querySelector("#user-name");
-    if (headerName) headerName.textContent = name;
-    document.querySelectorAll(".user-name").forEach(el => el.textContent = name);
-    document.querySelectorAll(".user-email").forEach(el => el.textContent = (user && user.email) || '');
-    document.querySelectorAll(".user-avatar").forEach(el => el.textContent = name.charAt(0).toUpperCase());
 }
 
 // =========================================
@@ -103,146 +80,288 @@ function formatDate(date) {
 
 // [핵심] 서버 데이터 요청 및 에러 처리
 async function fetchHomeData() {
-    const startDate = new Date(); startDate.setDate(today.getDate() - 30);
-    const endDate = new Date(); endDate.setDate(today.getDate() + 30);
-    const startStr = formatDate(startDate);
-    const endStr = formatDate(endDate);
+    const startDate = new Date(); startDate.setDate(today.getDate() - 30);
+    const endDate = new Date(); endDate.setDate(today.getDate() + 30);
+    const startStr = formatDate(startDate);
+    const endStr = formatDate(endDate);
 
-    try {
-        console.log(`📡 API 데이터 요청: ${startStr} ~ ${endStr}`);
-        const response = await fetch(`${API_BASE_URL}/events?startDate=${startStr}&endDate=${endStr}`, {
-            method: 'GET', credentials: 'include'
-        });
-if (response.ok) {
-            const data = await response.json();
-            const events = data.map(event => ({
-                ...event,
-                date: new Date(event.eventDate),
-                type: event.eventType === 'MEETING' ? 'meeting' : (event.eventType === 'TASK' ? 'personal' : 'other'),
-                important: event.isImportant,
-                completed: event.isCompleted || false
-            }));
-            console.log(`✅ 데이터 수신 완료: ${events.length}건`);
-            renderAllComponents(events);
-        } else {
-            // ⚠️ 401(인증) 또는 500(서버 오류) 발생 시, Google 연동 갱신 모달 표시
-            // [HEAD 버전의 긴급 수정 반영]: 500 에러 시에도 모달을 띄우도록 처리
-            console.warn(`⚠️ API 오류 발생 (Status: ${response.status})`);
-            if (response.status === 401 || response.status === 500) {
-                console.warn("👉 Google 연동 재시도 모달 실행");
-                showGoogleLinkModal(); 
-            }
-        }
-    } catch (error) {
-        console.error("❌ 네트워크 오류:", error);
-    }
+    try {
+        console.log(`📡 API 데이터 요청: ${startStr} ~ ${endStr}`);
+        const response = await fetch(`${API_BASE_URL}/events?startDate=${startStr}&endDate=${endStr}`, {
+            method: 'GET', credentials: 'include', cache: 'no-store'
+        });
+
+        if (response.ok) {
+            // 1. API 성공 시
+           const data = await response.json();
+           const events = data.map(event => {
+                let type;
+                if (event.eventType === 'MEETING') {
+                    type = 'meeting';
+                } else if (event.eventType === 'TASK' || event.eventType === 'PERSONAL') {
+                    type = 'personal';
+                } else {
+                    type = 'other';
+                }
+
+                return {
+                    ...event, // isCompleted: true가 여기에 포함됨
+                    date: new Date(event.eventDate),
+                    type: type,
+                    important: event.isImportant,
+                    completed: event.isCompleted // 덮어쓰지 않고 서버 값을 그대로 사용
+                };
+            });
+            console.log(`✅ 데이터 수신 완료: ${events.length}건`);
+            renderAllComponents(events);
+        } else {
+            // 2. API 실패 시 (401, 500 등)
+            console.warn(`⚠️ API 오류 발생 (Status: ${response.status})`);            
+
+            renderAllComponents([]); // <-- 빈 배열로 렌더링 호출
+        }
+    } catch (error) {
+        // 3. 네트워크 오류 시
+        console.error("❌ 네트워크 오류:", error);
+        // 네트워크 오류 시에도 'Empty State'를 띄우도록 빈 배열로 렌더링
+        renderAllComponents([]);
+    }
 }
 
 // =========================================
-// 4. Google 연동 모달 (확실하게 동작하도록 수정, feature/userrole 기반)
+// 4. Google 연동 배너 (Modal에서 Banner로 수정)
 // =========================================
-function showGoogleLinkModal() {
+function showGoogleLinkModal() { // 함수 이름은 유지하되, 내용은 배너로 변경
+    // 1. 기존 배너가 있으면 제거 (중복 방지)
+    const existingBanner = document.getElementById('googleLinkBanner'); // ID 변경
+    if (existingBanner) {
+        existingBanner.remove();
+    }
+
+    // 2. 배너 HTML (상단 고정 배너 스타일)
+    const bannerHtml = `
+                <div id="googleLinkBanner" class="google-link-banner">
+            <div class="banner-icon-text">
+                <span class="banner-icon">⚠️</span>             <p>
+                    <strong>Google 캘린더 연동 필요:</strong>
+                    최신 일정을 불러오기 위해 Google 계정 연동을 갱신해주세요.
+                </p>
+            </div>
+            <div class="banner-actions">
+                <button onclick="startGoogleLink()" class="google-btn">
+                    Google 계정으로 계속하기
+                </button>
+                                <button onclick="closeGoogleBanner()" class="banner-close-btn">×</button>
+            </div>
+        </div>
+    `;
+    
+    // 3. body에 추가
+    document.body.insertAdjacentHTML('beforeend', bannerHtml);
+
+    // 4. 애니메이션 시작
+    setTimeout(() => {
+        const banner = document.getElementById('googleLinkBanner'); // ID 변경
+        if (banner) {
+            banner.classList.add('visible'); 
+        }
+    }, 10);
+}
+
+// 전역 함수: 배너 닫기 (이름 변경: closeGoogleBanner)
+window.closeGoogleBanner = function() {
+    const banner = document.getElementById('googleLinkBanner'); // ID 변경
+    if (banner) {
+        banner.classList.remove('visible'); // visible 클래스 제거
+        
+        // 애니메이션(0.2s)이 끝난 후 DOM에서 완전히 제거
+        setTimeout(() => {
+            banner.remove();
+        }, 200); 
+    }
+};
+
+// 전역 함수: 연동 시작 (이 함수는 수정할 필요 없음)
+window.startGoogleLink = async function() {
+    try {
+        const res = await fetch('http://localhost:8080/api/calendar/link/start', {
+             method: 'GET', credentials: 'include' 
+        });
+        if (res.ok) {
+            const data = await res.json();
+            window.location.href = data.authUrl;
+        } else {
+            alert("연동 시작 실패. 서버 상태를 확인해주세요.");
+        }
+    } catch (e) {
+        console.error("연동 오류:", e);
+        alert("연동 중 오류가 발생했습니다.");
+    }
+};
+
+function openGoogleAuthModal() {
     // 1. 기존 모달이 있으면 제거 (중복 방지)
-    const existingModal = document.getElementById('googleLinkModal');
+    const existingModal = document.getElementById('googleAuthModal');
     if (existingModal) {
         existingModal.remove();
     }
 
-    // 2. 모달 HTML (feature/userrole 버전의 깔끔한 구조 채택)
+    // 2. 모달 HTML (home.css에 정의된 스타일 기반)
     const modalHtml = `
-        <div id="googleLinkModal" class="modal-overlay">
-            <div class="modal-content">
-                <button onclick="closeGoogleModal()" class="modal-close-btn">×</button>
-                <h3>Google 캘린더 연동 필요</h3>
-                <p>최신 일정을 불러오기 위해<br>Google 계정 연동을 갱신해주세요.</p>
-                <button onclick="startGoogleLink()" class="google-btn" style="cursor: pointer; width: 100%; padding: 12px; background-color: #4285F4; color: white; border: none; border-radius: 8px; font-weight: bold; font-size: 15px;">
-                    Google 계정으로 계속하기
-                </button>
+        <div id="googleAuthModal" class="modal-overlay">
+            <div class="modal-container">
+                <div class="modal-header">
+                    <h3>Google 캘린더 연동 필요</h3>
+                    <button onclick="closeGoogleAuthModal()" class="close-btn">×</button>
+                </div>
+                <div class="modal-body">
+                    최신 일정을 불러오기 위해<br>
+                    Google 계정 연동을 갱신해주세요.
+                </div>
+                <div class="modal-footer">
+                    <button onclick="startGoogleLink()" class="google-btn">
+                        Google 계정으로 계속하기
+                    </button>
+                </div>
             </div>
         </div>
     `;
     
     // 3. body에 추가
     document.body.insertAdjacentHTML('beforeend', modalHtml);
-    
-    // 4. 애니메이션을 위해 약간의 지연 후 '.visible' 클래스 추가
+
+    // 4. 애니메이션 시작 (home.css의 .modal-overlay.visible 스타일 사용)
     setTimeout(() => {
-        const modal = document.getElementById('googleLinkModal');
+        const modal = document.getElementById('googleAuthModal');
         if (modal) {
-            // CSS를 통해 opacity와 transform을 제어하는 'visible' 클래스 추가
             modal.classList.add('visible'); 
         }
     }, 10);
 }
 
-// 전역 함수: 모달 닫기 (feature/userrole 버전 채택)
-window.closeGoogleModal = function() {
-    const modal = document.getElementById('googleLinkModal');
+/**
+ * Google 연동 모달을 닫습니다. (전역으로 등록)
+ */
+window.closeGoogleAuthModal = function() {
+    const modal = document.getElementById('googleAuthModal');
     if (modal) {
-        modal.classList.remove('visible'); // visible 클래스 제거
-        
-        // 애니메이션(0.2s)이 끝난 후 DOM에서 완전히 제거
+        modal.classList.remove('visible');
+        // (home.css의 .modal-overlay transition이 0.3s = 300ms 임)
         setTimeout(() => {
             modal.remove();
-        }, 200); 
+        }, 300); 
     }
 };
 
-// 전역 함수: 연동 시작 (두 버전 동일)
-window.startGoogleLink = async function() {
-    try {
-        const res = await fetch('http://localhost:8080/api/calendar/link/start', {
-             method: 'GET', credentials: 'include' 
-        });
-        if (res.ok) {
-            const data = await res.json();
-            window.location.href = data.authUrl;
-        } else {
-            alert("연동 시작 실패. 서버 상태를 확인해주세요.");
-        }
-    } catch (e) {
-        console.error("연동 오류:", e);
-        alert("연동 중 오류가 발생했습니다.");
-    }
-};
 // =========================================
 //  5. UI 렌더링 함수들
 // =========================================
 function renderAllComponents(events) {
     renderTodoList(events);
     renderImportantMeetings(events);
-    renderRecentMeetings(events);
+    //renderRecentMeetings(events);
 }
 
 function renderTodoList(events) {
-    const listEl = document.querySelector('.todo-list');
-    if (!listEl) return;
-    const todayStr = formatDate(today);
-    const todos = events.filter(e => (e.eventType === 'TASK' || e.eventType === 'PERSONAL') && formatDate(e.date) === todayStr);
+    const listEl = document.querySelector('.todo-list');
+    if (!listEl) return;
+    const todayStr = formatDate(today);
+    const todos = events.filter(e => (e.eventType === 'TASK' || e.eventType === 'PERSONAL') && formatDate(e.date) === todayStr);
 
-    listEl.innerHTML = todos.length ? '' : '<div class="todo-item" style="justify-content: center; color: #9ca3af; padding: 12px 0;">오늘의 할 일이 없습니다</div>';
-    todos.forEach(todo => {
-        const item = document.createElement('div');
-        item.className = `todo-item ${todo.completed ? 'completed' : ''}`;
-        item.innerHTML = `<input type="checkbox" class="todo-checkbox" id="todo-${todo.id}" ${todo.completed ? 'checked' : ''}><label for="todo-${todo.id}" class="todo-label">${todo.title}</label>`;
-        item.querySelector('.todo-checkbox').addEventListener('change', async (e) => {
-            item.classList.toggle('completed', e.target.checked);
-            await updateTodoStatus(todo.id, e.target.checked);
-        });
-        listEl.appendChild(item);
-    });
+    if (todos.length === 0) {
+            listEl.innerHTML = '<div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">오늘의 할일이 없습니다.</div>';
+            return;
+        }
+
+    todos.forEach(todo => {
+        const item = document.createElement('div');
+        item.className = `todo-item ${todo.completed ? 'completed' : ''}`;
+        item.innerHTML = `<input type="checkbox" class="todo-checkbox" id="todo-${todo.id}" ${todo.completed ? 'checked' : ''}><label for="todo-${todo.id}" class="todo-label">${todo.title}</label>`;
+        item.querySelector('.todo-checkbox').addEventListener('change', async (e) => {
+            
+            // 1. e.target.checked 값 확인 (체크하면 true, 해제하면 false)
+            console.log("체크박스 변경:", e.target.checked); // 👈 (디버깅 로그 추가)
+
+            item.classList.toggle('completed', e.target.checked);
+
+            // 2. 이 함수로 e.target.checked 값이 그대로 전달되어야 합니다.
+            await updateTodoStatus(todo.id, e.target.checked);
+        });
+        listEl.appendChild(item);
+    });
 }
 
-function renderImportantMeetings(events) {
-    const listEl = document.querySelector('.deadline-list');
-    if (!listEl) return;
-    const todayOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-    const meetings = events.filter(e => (e.important || e.type === 'meeting') && e.date >= todayOnly).sort((a, b) => a.date - b.date).slice(0, 3);
+function renderImportantMeetings(events) { // 'events'는 필터링 전 원본 배열입니다.
+    const listEl = document.querySelector('.deadline-list');
+    if (!listEl) return;
+    const todayOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    
+    // 1. 필터 로직 (이것은 올바르게 수정되었습니다)
+    const meetings = events.filter(e => (e.important === true && e.type === 'meeting') && e.date >= todayOnly).sort((a, b) => a.date - b.date).slice(0, 3);
 
-    listEl.innerHTML = meetings.length ? '' : '<div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">예정된 중요 회의가 없습니다</div>';
-    meetings.forEach(m => {
-        const diff = Math.ceil((m.date - todayOnly) / (1000 * 60 * 60 * 24));
-        listEl.innerHTML += `<div class="deadline-item ${diff <= 3 ? 'urgent' : ''}"><div class="deadline-info"><div class="deadline-title">${m.title}</div><div class="deadline-meta"><span class="deadline-date">${m.date.getMonth() + 1}/${String(m.date.getDate()).padStart(2, '0')}</span><span class="deadline-badge ${diff <= 3 ? 'urgent' : ''}">${diff === 0 ? 'D-Day' : 'D-' + diff}</span></div></div></div>`;
+    // 2. "Google 연동" 버튼 HTML (API 실패 시 사용)
+    const emptyStateHtml = `
+        <div class="google-empty-state">
+            <span class="empty-state-icon">📅</span>
+            <p class="empty-state-text">
+                Google 캘린더를 연동하고<br>
+                중요한 회의 일정을 자동으로 불러오세요.
+            </p>
+            <button class="empty-state-button" onclick="openGoogleAuthModal()">
+                + Google 계정 연동하기
+            </button>
+        </div>`;
+    
+    // 3. "중요 회의 없음" 메시지 (API는 성공했으나, 필터 결과가 0건일 때 사용)
+    const noMeetingsHtml = `
+        <div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">
+            다가오는 중요한 회의가 없습니다.
+        </div>
+    `;
+
+    // 4. [로직 수정]
+    if (meetings.length > 0) {
+        // 1. 보여줄 중요 회의가 있음
+        listEl.innerHTML = '';
+    } else if (events.length > 0) {
+        // 2. API는 성공(events.length > 0)했지만, 필터된 중요 회의가 없음 (meetings.length === 0)
+        listEl.innerHTML = noMeetingsHtml;
+    } else {
+        // 3. API가 실패/오류 (events.length === 0)
+        listEl.innerHTML = emptyStateHtml;
+    }
+
+    // 5. 회의 목록 렌더링 (이 코드는 meetings.length > 0 일 때만 실행됨)
+    meetings.forEach(m => {
+        const diff = Math.ceil((m.date - todayOnly) / (1000 * 60 * 60 * 24));
+        listEl.innerHTML += `<div class="deadline-item ${diff <= 3 ? 'urgent' : ''}"><div class="deadline-info"><div class="deadline-title">${m.title}</div><div class="deadline-meta"><span class="deadline-date">${m.date.getMonth() + 1}/${String(m.date.getDate()).padStart(2, '0')}</span><span class="deadline-badge ${diff <= 3 ? 'urgent' : ''}">${diff === 0 ? 'D-Day' : 'D-' + diff}</span></div></div></div>`;
+    });
+}
+function loadRecentMeetings() {
+    console.log('🔄 "최근 회의" 데이터 로드 시작...');
+
+    // [수정] /api/calendar/events가 아닌 /api/meetings 호출
+    fetch('http://localhost:8080/api/meetings', {
+        method: 'GET',
+        credentials: 'include' 
+    })
+    .then(response => {
+        if (response.status === 401) throw new Error('인증 실패 (401)');
+        if (!response.ok) throw new Error('최근 회의 API 호출 실패');
+        return response.json();
+    })
+    .then(meetingList => { // DTO가 배열이라고 가정
+        const processedEvents = meetingList.map(meeting => ({
+            date: new Date(meeting.scheduledAt), // DTO 필드명 확인 필요
+            title: meeting.title,
+            type: 'meeting'
+        }));
+
+        renderRecentMeetings(processedEvents);
+    })
+    .catch(error => {
+        console.error('최근 회의 로딩 중 오류:', error);
+        renderRecentMeetings([]); 
     });
 }
 
@@ -250,6 +369,7 @@ function renderRecentMeetings(events) {
     const listEl = document.querySelector('.meeting-list');
     if (!listEl) return;
     const todayOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    // const meetings = events.filter(e => e.type === 'meeting' && e.date < todayOnly).sort((a, b) => b.date - a.date).slice(0, 3);
     const meetings = events.filter(e => e.type === 'meeting' && e.date < todayOnly).sort((a, b) => b.date - a.date).slice(0, 3);
 
     listEl.innerHTML = meetings.length ? '' : '<div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">최근 회의 기록이 없습니다</div>';
@@ -258,10 +378,22 @@ function renderRecentMeetings(events) {
     });
 }
 
-async function updateTodoStatus(todoId, isCompleted) {
-    try { await fetch(`${API_BASE_URL}/events/${todoId}/completion`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, credentials: 'include' }); } catch (e) { console.error(e); }
-}
 
+async function updateTodoStatus(todoId, isCompleted) {
+    // 👇 (디버깅 로그 추가)
+    console.log(`서버로 전송: ID=${todoId}, 완료상태=${isCompleted}`); 
+
+    try { 
+        await fetch(`${API_BASE_URL}/events/${todoId}/completion`, { 
+            method: 'PATCH', 
+            headers: { 'Content-Type': 'application/json' }, 
+            credentials: 'include',
+            body: JSON.stringify({ isCompleted: isCompleted }) // 👈 이 isCompleted가 true여야 합니다.
+        }); 
+    } catch (e) { 
+        console.error(e); 
+    }
+}
 // 기타 리스너
-document.addEventListener('visibilitychange', () => { if (!document.hidden) fetchHomeData(); });
+//document.addEventListener('visibilitychange', () => { if (!document.hidden) fetchHomeData(); });
 function goToMeetings() { window.location.href = 'meetings.html'; }

--- a/static/js/user-management.js
+++ b/static/js/user-management.js
@@ -52,53 +52,91 @@ function addUser() {
   alert('신규 유저 추가!');
 }
 
-async function loadUsers() {
-  try {
-    const response = await apiClient.get('/admin/users');
-    const users = response.data;
+// async function loadUsers() {
+//   try {
+//     const response = await apiClient.get('/admin/users');
+//     const users = response.data;
 
-    cachedUsers = users; 
+//     cachedUsers = users; 
     
-    const tbody = document.querySelector('.users-table tbody');
-    if (!tbody) {
-        console.error("테이블 <tbody>를 찾을 수 없습니다.");
-        return;
-    }
-    tbody.innerHTML = ''; 
+//     const tbody = document.querySelector('.users-table tbody');
+//     if (!tbody) {
+//         console.error("테이블 <tbody>를 찾을 수 없습니다.");
+//         return;
+//     }
+//     tbody.innerHTML = ''; 
 
-    if (!users || users.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">등록된 사용자가 없습니다.</td></tr>';
-        return;
-    }
+//     if (!users || users.length === 0) {
+//         tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">등록된 사용자가 없습니다.</td></tr>';
+//         return;
+//     }
 
-    users.forEach(user => {
-      const tr = document.createElement('tr');
+//     users.forEach(user => {
+//       const tr = document.createElement('tr');
       
-      // ✅ 디버깅: 콘솔에 user 객체 출력
-      console.log('User data:', user);
+//       // ✅ 디버깅: 콘솔에 user 객체 출력
+//       console.log('User data:', user);
       
-      tr.innerHTML = `
-        <td>${user.name || '이름 없음'}</td>
-        <td>${user.email || '-'}</td>
-        <td><span class="role-badge ${user.role ? user.role.toLowerCase() : 'user'}">${user.role || 'USER'}</span></td>
-        <td><span class="user-status ${user.active ? 'active' : 'deactivated'}">${user.active ? '활성' : '비활성'}</span></td>
-        <td>${user.regDate ? new Date(user.regDate).toLocaleDateString('ko-KR') : '-'}</td>
-        <td>
-          <div class="user-actions">
-            <button class="small-action-btn" onclick="editUser('${user.id}')">수정</button>
-            <button class="small-action-btn danger" onclick="deleteUser('${user.id}')">삭제</button>
-          </div>
-        </td>
-      `;
-      tbody.appendChild(tr);
-    });
-  } catch (error) {
-    console.error('유저 목록 로드 실패:', error);
-    const tbody = document.querySelector('.users-table tbody');
-    if (tbody) {
-        tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">목록을 불러오는 데 실패했습니다.</td></tr>';
-    }
-  }
+//       tr.innerHTML = `
+//         <td>${user.name || '이름 없음'}</td>
+//         <td>${user.email || '-'}</td>
+//         <td><span class="role-badge ${user.role ? user.role.toLowerCase() : 'user'}">${user.role || 'USER'}</span></td>
+//         <td><span class="user-status ${user.active ? 'active' : 'deactivated'}">${user.active ? '활성' : '비활성'}</span></td>
+//         <td>${user.regDate ? new Date(user.regDate).toLocaleDateString('ko-KR') : '-'}</td>
+//         <td>
+//           <div class="user-actions">
+//             <button class="small-action-btn" onclick="editUser('${user.id}')">수정</button>
+//             <button class="small-action-btn danger" onclick="deleteUser('${user.id}')">삭제</button>
+//           </div>
+//         </td>
+//       `;
+//       tbody.appendChild(tr);
+//     });
+//   } catch (error) {
+//     console.error('유저 목록 로드 실패:', error);
+//     const tbody = document.querySelector('.users-table tbody');
+//     if (tbody) {
+//         tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">목록을 불러오는 데 실패했습니다.</td></tr>';
+//     }
+//   }
+// }
+
+async function loadUsers() {
+  try {
+    const response = await apiClient.get('/admin/users');
+    const users = response.data;
+
+    cachedUsers = users; 
+    
+    const tbody = document.querySelector('.users-table tbody');
+    if (!tbody) {
+        console.error("테이블 <tbody>를 찾을 수 없습니다.");
+        return;
+    }
+    tbody.innerHTML = ''; 
+
+    if (!users || users.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">등록된 사용자가 없습니다.</td></tr>';
+        return;
+    }
+
+    users.forEach(user => {
+      const tr = document.createElement('tr');
+      
+      // ✅ 디버깅: 콘솔에 user 객체 출력
+      console.log('User data:', user);
+      
+
+      tr.innerHTML = `<td>${user.name || '이름 없음'}</td><td>${user.email || '-'}</td><td><span class="role-badge ${user.role ? user.role.toLowerCase() : 'user'}">${user.role || 'USER'}</span></td><td><select class="user-status ${user.active ? 'active' : 'deactivated'}" onchange="updateUserStatus(this, '${user.id}', this.value)"><option value="true" ${user.active ? 'selected' : ''}>활성</option><option value="false" ${!user.active ? 'selected' : ''}>비활성</option></select></td><td>${user.regDate ? new Date(user.regDate).toLocaleDateString('ko-KR') : '-'}</td><td><div class="user-actions"><button class="small-action-btn" onclick="editUser('${user.id}')">수정</button><button class="small-action-btn danger" onclick="deleteUser('${user.id}')">삭제</button></div></td>`;
+      tbody.appendChild(tr);
+    });
+  } catch (error) {
+    console.error('유저 목록 로드 실패:', error);
+    const tbody = document.querySelector('.users-table tbody');
+    if (tbody) {
+        tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;">목록을 불러오는 데 실패했습니다.</td></tr>';
+    }
+  }
 }
 
 function editUser(userId) {
@@ -166,4 +204,59 @@ async function deleteUser(userId) {
         alert('삭제 중 오류가 발생했습니다.');
     }
   }
+}
+
+/**
+ * 사용자 상태(활성/비활성)를 변경하는 함수
+ * (기존 UserSettingsUpdateDto를 재활용하여 PUT으로 전송)
+ * @param {HTMLSelectElement} selectElement - 변경이 일어난 <select> 요소 (this)
+ * @param {string} userId - 변경할 사용자의 ID
+ * @param {string} newStatusValue - 새로운 상태 값 ("true" 또는 "false")
+ */
+async function updateUserStatus(selectElement, userId, newStatusValue) {
+    
+    const isActive = (newStatusValue === 'true'); 
+
+    // 1. (⭐️중요⭐️) 캐시된 데이터에서 이 사용자의 job, position을 찾습니다.
+    //    @NotNull 필드를 채워야 하기 때문입니다.
+    const user = cachedUsers.find(u => u.id == userId);
+    if (!user) {
+        alert('캐시된 사용자 정보를 찾을 수 없어 상태를 변경할 수 없습니다.');
+        return;
+    }
+
+    // 2. 시각적 스타일 즉시 업데이트
+    if (isActive) {
+        selectElement.classList.remove('deactivated');
+        selectElement.classList.add('active');
+    } else {
+        selectElement.classList.remove('active');
+        selectElement.classList.add('deactivated');
+    }
+
+    try {
+        // 3. 백엔드로 보낼 DTO 객체 생성 (UserSettingsUpdateDto)
+        const updateDto = {
+            job: user.job,           // 캐시에서 가져온 기존 값
+            position: user.position, // 캐시에서 가져온 기존 값
+            active: isActive         // ⭐️새롭게 변경된 상태 값
+        };
+        await apiClient.put(`/admin/users/settings/${userId}`, updateDto);        
+        // 5. API가 성공했으므로, JS 캐시에도 상태를 반영합니다.
+        user.active = isActive;
+
+    } catch (error) {
+        console.error('사용자 상태 변경 실패:', error);
+        alert('상태 변경 중 오류가 발생했습니다.');
+
+        // 6. (실패 시) 시각적 스타일을 원래대로 롤백
+        selectElement.value = !isActive; // <select> 값 되돌리기
+        if (isActive) {
+            selectElement.classList.remove('active');
+            selectElement.classList.add('deactivated');
+        } else {
+            selectElement.classList.remove('deactivated');
+            selectElement.classList.add('active');
+        }
+    }
 }


### PR DESCRIPTION
## **구현 기능 요약**
1. '중요 회의' 토글 기능 구현
- 일정 관리 페이지에서 '별(★)' 아이콘을 클릭하여 중요 일정을 지정 후 이 상태가 DB에 저장되어 홈 화면에 연동되도록 구현
- 기능 구현 중 발견된 JPA 엔티티와 DB 컬럼의 매핑 누락으로 인해 DB 저장이 실패하던 버그를 추적하고 해결

2. '사용자 활성/비활성' 기능 구현 (Admin & **Security)
- 관리자 페이지에서 사용자의 계정 상태를 '활성' 또는 '비활성'으로 변경할 수 있는 기능을 구현
- Spring Security와 연동하여, 비활성된 사용자는 즉시 로그인이 차단되거나 기존 세션에서 강제 로그아웃되도록 구현
---

## **개발 내역 상세**

1. '중요 회의' 기능

[UI/Frontend]

 - calendar.js: '일정 관리' 페이지의 각 회의 항목 우측에 '별(★)' 아이콘을 추가했습니다.

 - calendar.js: 별 아이콘 클릭 시, toggleImportance JS 함수가 PATCH /api/calendar/{eventId}/importance API를 호출하여 서버에 중요도 변경을 요청합니다.

 - home.js: 홈 페이지에 "다가오는 중요 회의" 섹션을 신설하고, API로 받은 일정 중 isImportant: true인 항목만 필터링하여 표시합니다.

2. '사용자 활성/비활성' 기능 (Admin & Security)

[Admin UI]

- admin.css: table-layout: fixed 및 width 속성을 조정하여, 관리자 페이지의 사용자 목록 테이블 UI가 깨지거나 일그러지는 현상을 해결했습니다.
[Frontend (Global)]

- app.js (API Interceptor): 모든 401 응답을 감지하며, 응답 본문에 "계정이 비활성화되었습니다" 메시지가 포함된 경우, 사용자에게 알림을 띄우고 강제 로그아웃을 실행합니다.

---

## **검증 방법**
1. '중요 회의' 기능 검증

- '일정 관리' 페이지로 이동하여 특정 회의의 '별(★)' 아이콘을 클릭하여 활성화합니다.

- 페이지를 새로고침(F5)해도 '별' 아이콘이 활성화 상태로 유지되는지 확인합니다.

- (선택) DB calendar_event 테이블에서 해당 이벤트의 is_important 컬럼이 1 (또는 true)로 변경되었는지 확인합니다.

- '홈' 페이지로 이동하여 "다가오는 중요 회의" 섹션에 방금 중요 표시한 일정이 즉시 표시되는지 확인합니다.

- 다시 '별' 아이콘을 클릭하여 비활성화하고 홈 페이지로 돌아왔을 때, 해당 일정이 섹션에서 사라지는지 확인합니다.

2. '사용자 활성/비활성' 기능 검증

- (Admin 계정) '관리자 페이지'로 이동하여 테스트용 사용자 계정을 '비활성'으로 변경합니다.

- (선택) DB meet_user 테이블에서 해당 유저의 active 컬럼이 0 (또는 false)로 변경되었는지 확인합니다.

- (테스트 시나리오 A: 신규 로그인) 다른 브라우저에서 '비활성' 처리된 계정으로 로그인을 시도합니다. "계정이 비활성화되었습니다" (또는 설정한 메시지)가 표시되며 로그인이 실패하는지 확인합니다.

- (테스트 시나리오 B: 기존 로그인) 이미 로그인된 상태의 '비활성' 사용자가 캘린더 이동 등 API 요청을 시도할 때, "계정이 비활성화되었습니다" 알림과 함께 강제 로그아웃되는지 확인합니다.

- (Admin 계정) 다시 사용자를 '활성'으로 변경하고, 해당 계정으로 로그인이 정상적으로 되는지 확인합니다.
---

