### PR TITLE
feat: [FE] 메인 페이지 개인별 통계 API 구현 및 UI 연동

### DIFF
--- a/home.html
+++ b/home.html
@@ -11,16 +11,9 @@
 
 <body>
   <div class="container">
-
-    <!-- Sidebar Trigger Zone -->
     <div class="sidebar-trigger"></div>
-
-    <!-- Sidebar (fetch로 불러올 자리) -->
     <div id="sidebar-container"></div>
-
-    <!-- Main Content -->
     <main class="main-content">
-      <!-- Main Page -->
       <div id="mainPage" class="content-wrapper">
         <div class="page-header" style="display: flex; align-items: center; gap: 10px;">
           <h2 style="margin:0;">안녕하세요, <span id="user-name">사용자</span>님</h2>
@@ -34,7 +27,6 @@
           </button>
         </div>
         <p id="current-date-display">오늘도 생산적인 하루를 만들어가세요</p><br>
-        <!-- </div> -->
 
         <div class="cta-banner">
           <h3>새로운 회의를 시작할 준비가 되셨나요?</h3>
@@ -47,7 +39,6 @@
           </button>
         </div>
 
-        <!-- 3개 카드 1열 배치 -->
         <div class="three-col-grid">
           <div class="card">
             <div class="card-header">
@@ -55,8 +46,7 @@
               <a class="card-link" onclick="goToMeetings()">전체보기</a>
             </div>
             <div class="meeting-list">
-              <!-- JavaScript로 동적 렌더링 -->
-            </div>
+              </div>
           </div>
 
           <div class="card">
@@ -64,8 +54,7 @@
               <h3 class="card-title">다가오는 중요회의</h3>
             </div>
             <div class="deadline-list">
-              <!-- JavaScript로 동적 렌더링 -->
-            </div>
+              </div>
           </div>
 
           <div class="card">
@@ -73,8 +62,7 @@
               <h3 class="card-title">To-Do</h3>
             </div>
             <div class="todo-list">
-              <!-- JavaScript로 동적 렌더링 -->
-            </div>
+              </div>
           </div>
         </div>
 
@@ -88,10 +76,11 @@
             </div>
             <div class="stat-label">이번 달 회의</div>
             <div class="stat-value-row">
-              <div class="stat-value">24</div>
-              <div class="stat-change">+12%</div>
+              <div class="stat-value" id="stat-meeting-count">-</div>
+              <div class="stat-change" id="stat-meeting-diff">--</div>
             </div>
           </div>
+
           <div class="stat-card">
             <div class="stat-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -101,10 +90,11 @@
             </div>
             <div class="stat-label">총 참여 시간</div>
             <div class="stat-value-row">
-              <div class="stat-value">18h</div>
-              <div class="stat-change">+8%</div>
+              <div class="stat-value" id="stat-total-time">-</div>
+              <div class="stat-change" id="stat-time-diff">--</div>
             </div>
           </div>
+
           <div class="stat-card">
             <div class="stat-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -114,10 +104,11 @@
             </div>
             <div class="stat-label">미결 액션아이템</div>
             <div class="stat-value-row">
-              <div class="stat-value">7개</div>
-              <div class="stat-change">+2개</div>
+              <div class="stat-value" id="stat-action-items">-</div>
+              <div class="stat-change" id="stat-action-diff">--</div>
             </div>
           </div>
+
           <div class="stat-card">
             <div class="stat-icon">
               <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -125,18 +116,16 @@
                 <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
               </svg>
             </div>
-            <div class="stat-label">확정된 주요결정사항</div>
+            <div class="stat-label">종료된 회의</div>
             <div class="stat-value-row">
-              <div class="stat-value">12건</div>
-              <div class="stat-change">+8%</div>
+              <div class="stat-value" id="stat-decisions">-</div>
+              <div class="stat-change" id="stat-decision-diff">--</div>
             </div>
           </div>
         </div>
       </div>
-      <!-- 챗봇 컨테이너 -->
-      <div id="chatbot-container"></div>
 
-      <!-- 플로팅 버튼 -->
+      <div id="chatbot-container"></div>
       <button class="floating-chat-btn" id="floatingChatBtn">
         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
@@ -144,33 +133,30 @@
       </button>
     </main>
   </div>
-<div id="jobPersonaModal" class="job-modal-overlay">
+
+  <div id="jobPersonaModal" class="job-modal-overlay">
     <div class="job-modal-content">
-        <h3 class="job-modal-title">직무를 설정해보세요!</h3>
-        <p class="job-modal-desc">
-            나의 직무(백엔드, 프론트 등)를 설정하면<br>
-            AI 챗봇이 더 정확하고 전문적인 답변을 제공합니다.
-        </p>
-        
-        <div class="job-modal-actions">
-            <button onclick="closeJobModal(false)" class="job-modal-btn btn-secondary">
-                나중에
-            </button>
-            <button onclick="location.href='/settings.html'" class="job-modal-btn btn-primary">
-                지금 설정하기
-            </button>
-        </div>
-        
-        <div class="job-modal-footer">
-            <a href="#" onclick="closeJobModal(true)">다시 보지 않기</a>
-        </div>
+      <h3 class="job-modal-title">직무를 설정해보세요!</h3>
+      <p class="job-modal-desc">
+        나의 직무(백엔드, 프론트 등)를 설정하면<br>
+        AI 챗봇이 더 정확하고 전문적인 답변을 제공합니다.
+      </p>
+      <div class="job-modal-actions">
+        <button onclick="closeJobModal(false)" class="job-modal-btn btn-secondary">
+          나중에
+        </button>
+        <button onclick="location.href='/settings.html'" class="job-modal-btn btn-primary">
+          지금 설정하기
+        </button>
+      </div>
+      <div class="job-modal-footer">
+        <a href="#" onclick="closeJobModal(true)">다시 보지 않기</a>
+      </div>
     </div>
-</div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   <script src="static/js/app.js"></script>
   <script src="static/js/home.js"></script>
-
-  <link rel="stylesheet" href="static/css/home.css">
 </body>
-
 </html>

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -2,38 +2,54 @@
    [통합] 홈 화면 전용 JS (home.js)
 ================================= */
 
-document.addEventListener("DOMContentLoaded", () => {
-    loadCommonComponents();
+document.addEventListener("DOMContentLoaded", async () => {
+    // 1. 공통 컴포넌트 로드 (사이드바, 챗봇 등)
+    // await을 써서 컴포넌트 로드가 끝날 때까지 기다립니다. (loadCommonComponents 수정 필요)
+    await loadCommonComponents(); 
+
+    // 2. 사용자 정보 확인 (로그인 상태 체크)
+    // app.js에 있는 loadCurrentUser가 완료된 후 데이터를 불러옵니다.
+    if (typeof loadCurrentUser === 'function') {
+        const user = await loadCurrentUser(); 
+        if (!user) return; // 로그인이 안 되어 있으면 중단 (loadCurrentUser 내부에서 리다이렉트 처리됨)
+    }
+
+    // 3. 데이터 로드 (이제 안전하게 호출 가능)
     initHomeData();
     loadRecentMeetings();
     checkAndShowJobModal();
 });
 
-// =========================================
-//  1. 공통 컴포넌트 로드
-// =========================================
-function loadCommonComponents() {
-    fetch("components/chatbot.html")
+// loadCommonComponents를 async로 변경하고 Promise를 반환하도록 수정
+async function loadCommonComponents() {
+    const promises = [];
+
+    // 챗봇 로드
+    const chatbotPromise = fetch("components/chatbot.html")
         .then(res => res.text())
         .then(html => {
             const container = document.getElementById("chatbot-container");
             if (container) {
                 container.innerHTML = html;
                 initChatbotEventListeners();
-                loadCurrentUser();
             }
         });
+    promises.push(chatbotPromise);
 
-    fetch("components/sidebar.html")
+    // 사이드바 로드
+    const sidebarPromise = fetch("components/sidebar.html")
         .then(res => res.text())
         .then(html => {
             const sidebar = document.getElementById("sidebar-container");
             if (sidebar) {
                 sidebar.innerHTML = html;
                 activateCurrentNav(sidebar);
-                loadCurrentUser();
             }
         });
+    promises.push(sidebarPromise);
+
+    // 모든 로드가 끝날 때까지 기다림
+    await Promise.all(promises);
 }
 
 function initChatbotEventListeners() {
@@ -51,21 +67,30 @@ function initChatbotEventListeners() {
 function activateCurrentNav(sidebar) {
     const currentPage = window.location.pathname.split("/").pop();
     sidebar.querySelectorAll(".nav-menu a").forEach(item => {
-        item.classList.toggle("active", item.getAttribute("href") === currentPage);
+        const href = item.getAttribute("href");
+        // home.html 인 경우 / 또는 home.html 모두 활성화
+        if (href === currentPage || (currentPage === "" && href === "home.html")) {
+            item.classList.add("active");
+        } else {
+            item.classList.remove("active");
+        }
     });
 }
 
 // =========================================
-//  3. 홈 데이터 관리 (API 기반)
+//  2. 홈 데이터 초기화 및 API 설정
 // =========================================
-// [수정] app.js의 API_BASE_URL과 충돌 방지를 위해 CALENDAR_API_BASE로 변경
 const CALENDAR_API_BASE = 'http://localhost:8080/api/calendar';
+const HOME_API_BASE = 'http://localhost:8080/api/home'; // [신규] 통계용 API
 const today = new Date();
 
 async function initHomeData() {
     console.log('🏠 홈 데이터 초기화 시작');
     displayCurrentDate();
-    await fetchHomeData();
+    
+    // 병렬로 호출하여 로딩 속도 최적화 가능하지만, 순차 호출로 안정성 확보
+    await fetchHomeData(); // 상단 3개 카드 (캘린더/Todo)
+    await loadHomeStats(); // [신규] 하단 4개 통계 카드
 }
 
 function displayCurrentDate() {
@@ -80,25 +105,25 @@ function formatDate(date) {
     return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
 }
 
-// [핵심] 서버 데이터 요청 및 에러 처리
+// =========================================
+//  3. 상단 카드 데이터 (일정, Todo) 로드
+// =========================================
 async function fetchHomeData() {
-    const startDate = new Date(); startDate.setDate(today.getDate() - 30);
-    const endDate = new Date(); endDate.setDate(today.getDate() + 30);
-    const startStr = formatDate(startDate);
-    const endStr = formatDate(endDate);
+    const startDate = new Date(); startDate.setDate(today.getDate() - 30);
+    const endDate = new Date(); endDate.setDate(today.getDate() + 30);
+    const startStr = formatDate(startDate);
+    const endStr = formatDate(endDate);
 
-    try {
-        console.log(`📡 API 데이터 요청: ${startStr} ~ ${endStr}`);
+    try {
+        console.log(`📡 일정/할일 데이터 요청: ${startStr} ~ ${endStr}`);
 
-        // [수정] app.js와 충돌 방지를 위해 CALENDAR_API_BASE 사용
-        const response = await fetch(`${CALENDAR_API_BASE}/events?startDate=${startStr}&endDate=${endStr}`, {
-            method: 'GET', credentials: 'include', cache: 'no-store'
-        });
+        const response = await fetch(`${CALENDAR_API_BASE}/events?startDate=${startStr}&endDate=${endStr}`, {
+            method: 'GET', credentials: 'include', cache: 'no-store'
+        });
 
-        if (response.ok) {
-            // 1. API 성공 시
-           const data = await response.json();
-           const events = data.map(event => {
+        if (response.ok) {
+            const data = await response.json();
+            const events = data.map(event => {
                 let type;
                 if (event.eventType === 'MEETING') {
                     type = 'meeting';
@@ -109,284 +134,87 @@ async function fetchHomeData() {
                 }
 
                 return {
-                    ...event, // isCompleted: true가 여기에 포함됨
+                    ...event, 
                     date: new Date(event.eventDate),
                     type: type,
                     important: event.isImportant,
-                    completed: event.isCompleted // 덮어쓰지 않고 서버 값을 그대로 사용
+                    completed: event.isCompleted
                 };
             });
-            console.log(`✅ 데이터 수신 완료: ${events.length}건`);
-            renderAllComponents(events);
-        } else {
-            // 2. API 실패 시 (401, 500 등)
-            console.warn(`⚠️ API 오류 발생 (Status: ${response.status})`);            
-
-            renderAllComponents([]); // <-- 빈 배열로 렌더링 호출
-        }
-    } catch (error) {
-        // 3. 네트워크 오류 시
-        console.error("❌ 네트워크 오류:", error);
-        // 네트워크 오류 시에도 'Empty State'를 띄우도록 빈 배열로 렌더링
+            console.log(`✅ 일정/할일 수신 완료: ${events.length}건`);
+            renderAllComponents(events);
+        } else {
+            console.warn(`⚠️ API 오류 발생 (Status: ${response.status})`);
+            // 401(Unauthorized)이나 500 등의 에러 발생 시 구글 연동 배너 표시 고려
+            if (response.status === 401 || response.status === 500) {
+                 showGoogleLinkModal(); // 배너 표시
+            }
+            renderAllComponents([]);
+        }
+    } catch (error) {
+        console.error("❌ 네트워크 오류:", error);
         renderAllComponents([]);
-    }
-}
-
-// =========================================
-// 4. Google 연동 배너 (Modal에서 Banner로 수정)
-// =========================================
-function showGoogleLinkModal() { // 함수 이름은 유지하되, 내용은 배너로 변경
-    // 1. 기존 배너가 있으면 제거 (중복 방지)
-    const existingBanner = document.getElementById('googleLinkBanner'); // ID 변경
-    if (existingBanner) {
-        existingBanner.remove();
-    }
-
-    // 2. 배너 HTML (상단 고정 배너 스타일)
-    const bannerHtml = `
-                <div id="googleLinkBanner" class="google-link-banner">
-            <div class="banner-icon-text">
-                <span class="banner-icon">⚠️</span>             <p>
-                    <strong>Google 캘린더 연동 필요:</strong>
-                    최신 일정을 불러오기 위해 Google 계정 연동을 갱신해주세요.
-                </p>
-            </div>
-            <div class="banner-actions">
-                <button onclick="startGoogleLink()" class="google-btn">
-                    Google 계정으로 계속하기
-                </button>
-                                <button onclick="closeGoogleBanner()" class="banner-close-btn">×</button>
-            </div>
-        </div>
-    `;
-    
-    // 3. body에 추가
-    document.body.insertAdjacentHTML('beforeend', bannerHtml);
-
-    // 4. 애니메이션 시작
-    setTimeout(() => {
-        const banner = document.getElementById('googleLinkBanner'); // ID 변경
-        if (banner) {
-            banner.classList.add('visible'); 
-        }
-    }, 10);
-}
-
-// 전역 함수: 배너 닫기 (이름 변경: closeGoogleBanner)
-window.closeGoogleBanner = function() {
-    const banner = document.getElementById('googleLinkBanner'); // ID 변경
-    if (banner) {
-        banner.classList.remove('visible'); // visible 클래스 제거
-        
-        // 애니메이션(0.2s)이 끝난 후 DOM에서 완전히 제거
-        setTimeout(() => {
-            banner.remove();
-        }, 200); 
-    }
-};
-
-// 전역 함수: 연동 시작 (이 함수는 수정할 필요 없음)
-window.startGoogleLink = async function() {
-    try {
-        const res = await fetch('http://localhost:8080/api/calendar/link/start', {
-             method: 'GET', credentials: 'include' 
-        });
-        if (res.ok) {
-            const data = await res.json();
-            window.location.href = data.authUrl;
-        } else {
-        showAlert("연동 시작에 실패했습니다. 서버 상태를 확인해주세요.", 'error');
-        }
-    } catch (e) {
-        console.error("연동 오류:", e);
-        showAlert("연동 중 오류가 발생했습니다.", 'error');
-    }
-};
-
-function openGoogleAuthModal() {
-    // 1. 기존 모달이 있으면 제거 (중복 방지)
-    const existingModal = document.getElementById('googleAuthModal');
-    if (existingModal) {
-        existingModal.remove();
     }
-
-    // 2. 모달 HTML (home.css에 정의된 스타일 기반)
-    const modalHtml = `
-        <div id="googleAuthModal" class="modal-overlay">
-            <div class="modal-container">
-                <div class="modal-header">
-                    <h3>Google 캘린더 연동 필요</h3>
-                    <button onclick="closeGoogleAuthModal()" class="close-btn">×</button>
-                </div>
-                <div class="modal-body">
-                    최신 일정을 불러오기 위해<br>
-                    Google 계정 연동을 갱신해주세요.
-                </div>
-                <div class="modal-footer">
-                    <button onclick="startGoogleLink()" class="google-btn">
-                        Google 계정으로 계속하기
-                    </button>
-                </div>
-            </div>
-        </div>
-    `;
-    
-    // 3. body에 추가
-    document.body.insertAdjacentHTML('beforeend', modalHtml);
-
-    // 4. 애니메이션 시작 (home.css의 .modal-overlay.visible 스타일 사용)
-    setTimeout(() => {
-        const modal = document.getElementById('googleAuthModal');
-        if (modal) {
-            modal.classList.add('visible'); 
-        }
-    }, 10);
 }
 
-/**
- * Google 연동 모달을 닫습니다. (전역으로 등록)
- */
-window.closeGoogleAuthModal = function() {
-    const modal = document.getElementById('googleAuthModal');
-    if (modal) {
-        modal.classList.remove('visible');
-        // (home.css의 .modal-overlay transition이 0.3s = 300ms 임)
-        setTimeout(() => {
-            modal.remove();
-        }, 300); 
+// =========================================
+//  4. 하단 통계 데이터 로드
+// =========================================
+async function loadHomeStats() {
+    console.log('📊 통계 데이터 로드 시작...');
+    try {
+        const response = await fetch(`${HOME_API_BASE}/stats`, {
+            method: 'GET',
+            credentials: 'include', // 쿠키 인증 포함
+            headers: { 'Content-Type': 'application/json' }
+        });
+
+        if (response.ok) {
+            const data = await response.json();
+            console.log('✅ 통계 데이터 수신 완료:', data);
+            
+            // 1. 이번 달 회의
+            updateStatCard('stat-meeting-count', data.thisMonthMeetingCount + '건', 'stat-meeting-diff', data.meetingCountDiff);
+            
+            // 2. 총 참여 시간
+            updateStatCard('stat-total-time', data.totalMeetingTime, 'stat-time-diff', data.meetingHoursDiff);
+            
+            // 3. 미결 액션아이템
+            updateStatCard('stat-action-items', data.openActionItems + '개', 'stat-action-diff', data.actionItemsDiff);
+            
+            // 4. 종료된 회의 (확정된 주요결정사항)
+            updateStatCard('stat-decisions', data.confirmedMeetings + '건', 'stat-decision-diff', data.meetingsDiff);
+
+        } else {
+            console.warn(`⚠️ 통계 API 오류 (Status: ${response.status})`);
+        }
+    } catch (error) {
+        console.error("❌ 통계 API 네트워크 오류:", error);
     }
-};
-
-// =========================================
-//  5. UI 렌더링 함수들
-// =========================================
-function renderAllComponents(events) {
-    renderTodoList(events);
-    renderImportantMeetings(events);
-    //renderRecentMeetings(events);
 }
 
-function renderTodoList(events) {
-    const listEl = document.querySelector('.todo-list');
-    if (!listEl) return;
-    const todayStr = formatDate(today);
-    const todos = events.filter(e => (e.eventType === 'TASK' || e.eventType === 'PERSONAL') && formatDate(e.date) === todayStr);
+// 통계 카드 업데이트 헬퍼 함수
+function updateStatCard(valueId, valueText, diffId, diffText) {
+    const valueEl = document.getElementById(valueId);
+    const diffEl = document.getElementById(diffId);
 
-    if (todos.length === 0) {
-            listEl.innerHTML = '<div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">오늘의 할일이 없습니다.</div>';
-            return;
+    if (valueEl) valueEl.textContent = valueText;
+    if (diffEl) {
+        diffEl.textContent = diffText;
+        // 증감률 색상 처리 ('-' 포함 시 빨강, 아니면 보라)
+        if (diffText && diffText.includes('-')) {
+            diffEl.style.color = '#ef4444'; 
+        } else {
+            diffEl.style.color = '#8E44AD'; 
         }
-
-    todos.forEach(todo => {
-        const item = document.createElement('div');
-        item.className = `todo-item ${todo.completed ? 'completed' : ''}`;
-        item.innerHTML = `<input type="checkbox" class="todo-checkbox" id="todo-${todo.id}" ${todo.completed ? 'checked' : ''}><label for="todo-${todo.id}" class="todo-label">${todo.title}</label>`;
-        item.querySelector('.todo-checkbox').addEventListener('change', async (e) => {
-            
-            // 1. e.target.checked 값 확인 (체크하면 true, 해제하면 false)
-            console.log("체크박스 변경:", e.target.checked); 
-
-            item.classList.toggle('completed', e.target.checked);
-
-            // 2. 이 함수로 e.target.checked 값이 그대로 전달되어야 합니다.
-            await updateTodoStatus(todo.id, e.target.checked);
-        });
-        listEl.appendChild(item);
-    });
+    }
 }
 
-function renderImportantMeetings(events) { // 'events'는 필터링 전 원본 배열입니다.
-    const listEl = document.querySelector('.deadline-list');
-    if (!listEl) return;
-    const todayOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-    
-    // 1. 필터 로직 (이것은 올바르게 수정되었습니다)
-    const meetings = events.filter(e => (e.important === true && e.type === 'meeting') && e.date >= todayOnly).sort((a, b) => a.date - b.date).slice(0, 3);
-
-    // 2. "Google 연동" 버튼 HTML (API 실패 시 사용)
-   const emptyStateHtml = `
-    <div class="google-empty-state" style="
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
-        height: 100%;
-        padding: 20px;
-        box-sizing: border-box;
-    ">       
-
-        <p class="empty-state-text" style="
-            font-size: 14px;
-            color: #6b7280;
-            line-height: 1.6;
-            margin-top: 0;
-            margin-bottom: 24px;
-            text-align: center; /* 텍스트 자체도 가운데 정렬 */
-        ">
-            Google 캘린더를 연동하고<br>
-            중요한 회의 일정을 자동으로 불러오세요.
-        </p>
-
-        <button class="empty-state-button" style="
-            height: 34px;
-            padding: 0 14px;
-            font-size: 15px;
-            font-weight: 600;
-            display: flex;
-            align-items: center;
-            border-radius: 8px;
-            background: #8E44AD; /* 메인 보라색 */
-            color: #fff;
-            border: none;
-            cursor: pointer;
-        " onclick="openGoogleAuthModal()">
-            + Google 계정 연동하기
-        </button>
-    </div>`;
-    // 3. "중요 회의 없음" 메시지 (API는 성공했으나, 필터 결과가 0건일 때 사용)
-    const noMeetingsHtml = `
-        <div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">
-            다가오는 중요한 회의가 없습니다.
-        </div>
-    `;
-
-    // 4. [로직 수정]
-    if (meetings.length > 0) {
-        // 1. 보여줄 중요 회의가 있음
-        listEl.innerHTML = '';
-    } else if (events.length > 0) {
-        // 2. API는 성공(events.length > 0)했지만, 필터된 중요 회의가 없음 (meetings.length === 0)
-        listEl.innerHTML = noMeetingsHtml;
-    } else {
-        // 3. API가 실패/오류 (events.length === 0)
-        listEl.innerHTML = emptyStateHtml;
-    }
-
-    // 5. 회의 목록 렌더링 (이 코드는 meetings.length > 0 일 때만 실행됨)
-    meetings.forEach(m => {
-        const diff = Math.ceil((m.date - todayOnly) / (1000 * 60 * 60 * 24));
-        
-        // [수정 1] 날짜 문자열(YYYY-MM-DD) 생성
-        const dateStr = formatDate(m.date); 
-        
-        // [수정 2] HTML에 onclick과 style="cursor: pointer;" 추가
-        listEl.innerHTML += `
-            <div class="deadline-item ${diff <= 3 ? 'urgent' : ''}" 
-                 onclick="goToCalendarWithDate('${dateStr}')" 
-                 style="cursor: pointer;"
-                 title="클릭하여 캘린더에서 보기">
-                <div class="deadline-info">
-                    <div class="deadline-title">${m.title}</div>
-                    <div class="deadline-meta">
-                        <span class="deadline-date">${m.date.getMonth() + 1}/${String(m.date.getDate()).padStart(2, '0')}</span>
-                        <span class="deadline-badge ${diff <= 3 ? 'urgent' : ''}">${diff === 0 ? 'D-Day' : 'D-' + diff}</span>
-                    </div>
-                </div>
-            </div>`;
-    });
-}
+// =========================================
+//  5. 최근 회의 데이터 로드 (별도 API 사용 시)
+// =========================================
 function loadRecentMeetings() {
-    console.log('🔄 "최근 회의" 데이터 로드 시작... (통합 API 호출)');
+    console.log('🔄 "최근 회의" 데이터 로드 시작...');
 
     const endDate = new Date(today);
     const startDate = new Date(today);
@@ -395,17 +223,16 @@ function loadRecentMeetings() {
     const startStr = formatDate(startDate);
     const endStr = formatDate(endDate);
     
-    fetch(`http://localhost:8080/api/calendar/events?startDate=${startStr}&endDate=${endStr}`, {
+    fetch(`${CALENDAR_API_BASE}/events?startDate=${startStr}&endDate=${endStr}`, {
         method: 'GET',
         credentials: 'include' 
     })
     .then(response => {
         if (response.status === 401) throw new Error('인증 실패 (401)');
-        if (!response.ok) throw new Error('최근 회의 API(통합) 호출 실패');
+        if (!response.ok) throw new Error('최근 회의 API 호출 실패');
         return response.json();
     })
     .then(allEventsList => {    
-       
         const meetingsOnly = allEventsList.filter(e => e.eventType === 'MEETING');
         
         const processedEvents = meetingsOnly.map(meeting => ({
@@ -423,27 +250,123 @@ function loadRecentMeetings() {
     });
 }
 
+// =========================================
+//  6. UI 렌더링 (To-Do, 중요 회의, 최근 회의)
+// =========================================
+function renderAllComponents(events) {
+    renderTodoList(events);
+    renderImportantMeetings(events);
+}
+
+function renderTodoList(events) {
+    const listEl = document.querySelector('.todo-list');
+    if (!listEl) return;
+    const todayStr = formatDate(today);
+    
+    // 오늘 날짜의 TASK 또는 PERSONAL 이벤트 필터링
+    const todos = events.filter(e => (e.eventType === 'TASK' || e.eventType === 'PERSONAL') && formatDate(e.date) === todayStr);
+
+    if (todos.length === 0) {
+        listEl.innerHTML = '<div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">오늘의 할일이 없습니다.</div>';
+        return;
+    }
+
+    listEl.innerHTML = ''; // 초기화
+    todos.forEach(todo => {
+        const item = document.createElement('div');
+        item.className = `todo-item ${todo.completed ? 'completed' : ''}`;
+        item.innerHTML = `
+            <input type="checkbox" class="todo-checkbox" id="todo-${todo.id}" ${todo.completed ? 'checked' : ''}>
+            <label for="todo-${todo.id}" class="todo-label">${todo.title}</label>
+        `;
+        
+        // 체크박스 이벤트
+        item.querySelector('.todo-checkbox').addEventListener('change', async (e) => {
+            console.log("체크박스 변경:", e.target.checked); 
+            item.classList.toggle('completed', e.target.checked);
+            await updateTodoStatus(todo.id, e.target.checked);
+        });
+        listEl.appendChild(item);
+    });
+}
+
+function renderImportantMeetings(events) { 
+    const listEl = document.querySelector('.deadline-list');
+    if (!listEl) return;
+    
+    const todayOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    
+    // 필터: 중요(star) + 회의(meeting) + 오늘 이후
+    const meetings = events.filter(e => (e.important === true && e.type === 'meeting') && e.date >= todayOnly)
+                           .sort((a, b) => a.date - b.date)
+                           .slice(0, 3);
+
+    const emptyStateHtml = `
+    <div class="google-empty-state" style="display: flex; flex-direction: column; justify-content: center; align-items: center; height: 100%; padding: 20px;">       
+        <p class="empty-state-text" style="font-size: 14px; color: #6b7280; line-height: 1.6; margin-bottom: 24px; text-align: center;">
+            Google 캘린더를 연동하고<br>중요한 회의 일정을 자동으로 불러오세요.
+        </p>
+        <button class="empty-state-button" style="height: 34px; padding: 0 14px; font-size: 15px; font-weight: 600; display: flex; align-items: center; border-radius: 8px; background: #8E44AD; color: #fff; border: none; cursor: pointer;" onclick="openGoogleAuthModal()">
+            + Google 계정 연동하기
+        </button>
+    </div>`;
+
+    const noMeetingsHtml = `
+        <div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">
+            다가오는 중요한 회의가 없습니다.
+        </div>
+    `;
+
+    if (meetings.length > 0) {
+        listEl.innerHTML = '';
+        meetings.forEach(m => {
+            const diff = Math.ceil((m.date - todayOnly) / (1000 * 60 * 60 * 24));
+            const dateStr = formatDate(m.date); 
+            
+            listEl.innerHTML += `
+                <div class="deadline-item ${diff <= 3 ? 'urgent' : ''}" 
+                     onclick="goToCalendarWithDate('${dateStr}')" 
+                     style="cursor: pointer;"
+                     title="클릭하여 캘린더에서 보기">
+                    <div class="deadline-info">
+                        <div class="deadline-title">${m.title}</div>
+                        <div class="deadline-meta">
+                            <span class="deadline-date">${m.date.getMonth() + 1}/${String(m.date.getDate()).padStart(2, '0')}</span>
+                            <span class="deadline-badge ${diff <= 3 ? 'urgent' : ''}">${diff === 0 ? 'D-Day' : 'D-' + diff}</span>
+                        </div>
+                    </div>
+                </div>`;
+        });
+    } else if (events.length > 0) {
+        // 데이터는 있으나 중요 회의가 없음
+        listEl.innerHTML = noMeetingsHtml;
+    } else {
+        // 데이터 로드 실패 또는 데이터 0건 (연동 필요 상태로 가정)
+        listEl.innerHTML = emptyStateHtml;
+    }
+}
+
 function renderRecentMeetings(events) {
     const listEl = document.querySelector('.meeting-list');
     if (!listEl) return;
-    const todayOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-    const tomorrowOnly = new Date(todayOnly);
-    tomorrowOnly.setDate(todayOnly.getDate() + 1);
-    // const meetings = events.filter(e => e.type === 'meeting' && e.date < todayOnly).sort((a, b) => b.date - a.date).slice(0, 3);
+    
+    // 오늘을 포함하여 과거의 회의만 표시
+    const tomorrowOnly = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1);
+    
     const meetings = events.filter(e => e.type === 'meeting' && e.date < tomorrowOnly)
         .sort((a, b) => b.date - a.date) // 최신순 정렬
         .slice(0, 3); // 상위 3개
 
     listEl.innerHTML = meetings.length ? '' : '<div class="empty-message" style="color: #9ca3af; text-align: center; padding: 24px 0;">최근 회의 기록이 없습니다</div>';
+    
     meetings.forEach(m => {
         listEl.innerHTML += `
             <div class="meeting-item">
                 <div class="meeting-info">
-                    <div 
-                        class="meeting-title" 
-                        onclick="goToCalendarWithDate('${m.eventDateStr}')"
-                        style="cursor: pointer;"
-                        title="캘린더에서 이 날짜 보기">
+                    <div class="meeting-title" 
+                         onclick="goToCalendarWithDate('${m.eventDateStr}')"
+                         style="cursor: pointer;"
+                         title="캘린더에서 이 날짜 보기">
                         ${m.title}
                     </div>
                     <div class="meeting-meta">
@@ -455,11 +378,14 @@ function renderRecentMeetings(events) {
     });
 }
 
+// =========================================
+//  7. 액션 및 헬퍼 함수들
+// =========================================
 
+// To-Do 완료 상태 업데이트
 async function updateTodoStatus(todoId, isCompleted) {   
     console.log(`서버로 전송: ID=${todoId}, 완료상태=${isCompleted}`); 
-    try {
-        // [수정] CALENDAR_API_BASE 사용
+    try {
         await fetch(`${CALENDAR_API_BASE}/events/${todoId}/completion`, { 
             method: 'PATCH', 
             headers: { 'Content-Type': 'application/json' }, 
@@ -470,60 +396,138 @@ async function updateTodoStatus(todoId, isCompleted) {
         console.error(e); 
     }
 }
-function goToMeetings() { window.location.href = 'meetings.html'; }
 
-function goToCalendarWithDate(dateStr) {
-    window.location.href = `calendar.html?date=${dateStr}`;
+// 페이지 이동 헬퍼
+function goToMeetings() { window.location.href = 'meetings.html'; }
+function goToAdminDashboard() { window.location.href = 'dashboard.html'; }
+function goToCalendarWithDate(dateStr) { window.location.href = `calendar.html?date=${dateStr}`; }
+
+// =========================================
+//  8. Google 연동 모달 및 배너 로직
+// =========================================
+
+// (1) 배너 표시 함수 (자동 감지 시)
+function showGoogleLinkModal() { 
+    const existingBanner = document.getElementById('googleLinkBanner');
+    if (existingBanner) existingBanner.remove();
+
+    const bannerHtml = `
+        <div id="googleLinkBanner" class="google-link-banner">
+            <div class="banner-icon-text">
+                <span class="banner-icon">⚠️</span>
+                <p>
+                    <strong>Google 캘린더 연동 필요:</strong>
+                    최신 일정을 불러오기 위해 Google 계정 연동을 갱신해주세요.
+                </p>
+            </div>
+            <div class="banner-actions">
+                <button onclick="startGoogleLink()" class="google-btn">
+                    Google 계정으로 계속하기
+                </button>
+                <button onclick="closeGoogleBanner()" class="banner-close-btn">×</button>
+            </div>
+        </div>
+    `;
+    document.body.insertAdjacentHTML('beforeend', bannerHtml);
+    setTimeout(() => {
+        const banner = document.getElementById('googleLinkBanner');
+        if (banner) banner.classList.add('visible'); 
+    }, 10);
 }
 
-/* =========================================
-   직무 설정 유도 모달 로직
-========================================= */
-/* =========================================
-   직무 설정 유도 모달 로직
-========================================= */
+window.closeGoogleBanner = function() {
+    const banner = document.getElementById('googleLinkBanner');
+    if (banner) {
+        banner.classList.remove('visible');
+        setTimeout(() => banner.remove(), 200); 
+    }
+};
+
+// (2) 모달 표시 함수 (버튼 클릭 시)
+window.openGoogleAuthModal = function() {
+    const existingModal = document.getElementById('googleAuthModal');
+    if (existingModal) existingModal.remove();
+
+    const modalHtml = `
+        <div id="googleAuthModal" class="modal-overlay">
+            <div class="modal-container">
+                <div class="modal-header">
+                    <h3>Google 캘린더 연동 필요</h3>
+                    <button onclick="closeGoogleAuthModal()" class="close-btn">×</button>
+                </div>
+                <div class="modal-body" style="text-align:center; padding:20px;">
+                    <p style="color:#666; margin-bottom:20px;">
+                        최신 일정을 불러오기 위해<br>Google 계정 연동을 갱신해주세요.
+                    </p>
+                </div>
+                <div class="modal-footer">
+                    <button onclick="startGoogleLink()" class="google-btn" style="width:100%; justify-content:center;">
+                        Google 계정으로 계속하기
+                    </button>
+                </div>
+            </div>
+        </div>
+    `;
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    setTimeout(() => {
+        const modal = document.getElementById('googleAuthModal');
+        if (modal) modal.classList.add('visible'); 
+    }, 10);
+}
+
+window.closeGoogleAuthModal = function() {
+    const modal = document.getElementById('googleAuthModal');
+    if (modal) {
+        modal.classList.remove('visible');
+        setTimeout(() => modal.remove(), 300); 
+    }
+};
+
+// (3) 연동 시작 (공통)
+window.startGoogleLink = async function() {
+    try {
+        const res = await fetch(`${CALENDAR_API_BASE}/link/start`, {
+             method: 'GET', credentials: 'include' 
+        });
+        if (res.ok) {
+            const data = await res.json();
+            window.location.href = data.authUrl;
+        } else {
+            alert("연동 시작에 실패했습니다. 서버 상태를 확인해주세요.");
+        }
+    } catch (e) {
+        console.error("연동 오류:", e);
+        alert("연동 중 오류가 발생했습니다.");
+    }
+};
+
+// =========================================
+//  9. 직무 설정 유도 모달
+// =========================================
 function checkAndShowJobModal() {
-    // 1. 소셜 로그인 감지: URL 파라미터 확인 (?needJobSetup=true)
+    // 1. 소셜 로그인 리다이렉트 감지
     const urlParams = new URLSearchParams(window.location.search);
     const socialNeedSetup = urlParams.get('needJobSetup');
 
     if (socialNeedSetup === 'true') {
         sessionStorage.setItem('showJobPersonaModal', 'true');
-        
-        // URL 파라미터 청소 (지저분한 URL 정리)
         const cleanUrl = window.location.protocol + "//" + window.location.host + window.location.pathname;
         window.history.replaceState({path: cleanUrl}, '', cleanUrl);
     }
 
-    // 2. 모달 노출 조건 확인
-    // (일반 로그인은 login.js에서 sessionStorage에 저장했고, 소셜 로그인은 위에서 저장함)
+    // 2. 노출 조건 확인
     const shouldShow = sessionStorage.getItem('showJobPersonaModal');
-    const hideForever = localStorage.getItem('hideJobGuideForever'); // '다신 보지 않기' 값
+    const hideForever = localStorage.getItem('hideJobGuideForever');
 
-    // 3. 모달 띄우기
     if (shouldShow === 'true' && !hideForever) {
-        // 모달 요소 선택 (home.html에 해당 ID를 가진 모달이 있어야 함)
         const modal = document.getElementById('jobPersonaModal');
         if (modal) {
-            modal.style.display = 'flex'; // 모달 보이게 설정
+            modal.style.display = 'flex'; 
         }
-        
-        // 새로고침 시 계속 뜨지 않도록 세션 플래그 삭제 (원하는 정책에 따라 주석 처리 가능)
         sessionStorage.removeItem('showJobPersonaModal');
     }
 }
 
-// '다신 보지 않기' 및 닫기 처리 함수 (전역 window 객체에 등록)
-window.closeJobModal = function(neverShowAgain) {
-    const modal = document.getElementById('jobPersonaModal');
-    if (modal) {
-        modal.style.display = 'none';
-    }
-    if (neverShowAgain) {
-        localStorage.setItem('hideJobGuideForever', 'true');
-    }
-};
-// '다신 보지 않기' 및 닫기 처리 함수 (전역 window 객체에 등록)
 window.closeJobModal = function(neverShowAgain) {
     const modal = document.getElementById('jobPersonaModal');
     if (modal) {


### PR DESCRIPTION
## **구현 기능 요약**
* 메인 홈 화면(home.html) 하단에 위치한 4가지 핵심 지표(이번 달 회의, 총 참여 시간, 미결 액션아이템, 종료된 회의)를 하드코딩된 데이터  에서 사용자 실데이터 기반의 동적 통계로 전환

* 개인별 통계 제공: 로그인한 사용자의 데이터를 기반으로 월별 활동량을 집계합니다.

* 증감률 시각화: 지난달 대비 활동량 변화를 퍼센트(%) 또는 개수(건)로 계산하여 UI에 반영했습니다.

* 데이터 로딩 최적화: 페이지 초기화 시점의 비동기 처리 순서를 재정비하여 데이터 누락 문제를 해결했습니다.
---

## **개발 내역 상세**

* API 연동 (home.js):
* loadHomeStats() 함수를 구현하여 백엔드로부터 통계 DTO를 수신하고 DOM 요소에 바인딩
* updateStatCard() 헬퍼 함수를 통해 증감률이 양수일 때와 음수일 때의 색상(보라색/빨간색)을 동적으로 처리

* 초기화 로직 리팩토링 (Refactoring):
* 문제 해결: 로그인 직후 토큰이 준비되기 전에 데이터 API를 호출하여 401 에러가 발생하던 문제 해결
* 해결: DOMContentLoaded 이벤트 내에서 async/await 패턴 적용 [컴포넌트 로드] → [사용자 인증 확인] → [데이터 호출] 순서를 보장하도록 구조를 개선

---

## **검증 방법**
1. 데이터 정합성 확인:
     * 로그인 후 홈 화면 하단 카드의 숫자가 DB 데이터(이번 달 생성한 회의 수, 미완료 할 일 수)와 일치하는지 확인
2.시간 포맷 확인:
     * 회의 시간이 1시간 미만일 때(XXm)와 1시간 이상일 때(Xh YYm) 형식이 올바르게 표시되는지 확인
3. 초기 로딩 테스트:
     * 브라우저 강력 새로고침(Ctrl+F5) 시에도 데이터가 누락되지 않고 즉시 표시되는지 확인
4. 증감률 표시:
     * 데이터가 없는 경우(0건)와 있는 경우에 대해 퍼센트 표기가 정상적으로 계산되는지 확인
---

## **추가 개선 / TODO**
