### PR TITLE
fix: [FE] docker-compose 대신 순수 docker 명령어로 배포 안정화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,5 +63,12 @@ jobs:
           script: |
             cd /opt/dialog
             docker pull munwalk/dialog-frontend:latest
-            docker-compose up -d --no-deps --force-recreate frontend
+            docker stop dialog-frontend || true
+            docker rm dialog-frontend || true
+            docker run -d \
+              --name dialog-frontend \
+              --network dialog_default \
+              --restart unless-stopped \
+              -p 80:80 \
+              munwalk/dialog-frontend:latest
             docker ps | grep dialog-frontend


### PR DESCRIPTION
## 변경사항
docker-compose → 순수 docker 명령어로 변경
```yaml
docker stop dialog-frontend || true
docker rm dialog-frontend || true
docker run -d \
  --name dialog-frontend \
  --network dialog_default \
  --restart unless-stopped \
  -p 80:80 \
  munwalk/dialog-frontend:latest
```

## 이유
docker-compose 사용 시 네트워크 재구성으로 백엔드/DB 영향받음

## 효과
프론트엔드만 독립적으로 배포, 다른 서비스 무중단 보장