### PR TITLE
fix: [FE] Google 캘린더 연동 안내 및 도메인/HTTPS 설정 수정

### DIFF
--- a/meetings.html
+++ b/meetings.html
@@ -185,7 +185,6 @@
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   <script src="/static/js/app.js"></script>
   <script src="/static/js/meetings.js"></script>
-  <script src="/static/js/chatbot.js"></script>
 </body>
 
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,10 @@
 const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'http://dialogai.duckdns.org:8080';
-const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'http://dialogai.duckdns.org:8000';
+
+// [수정] HTTPS 적용 - Caddy가 프록시하므로 포트 번호 제거
+// const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.duckdns.org';
+// const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.duckdns.org';
+const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.ddns.net';
+const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.ddns.net';
 
 // ============================================================
 // API URL 설정

--- a/static/js/resetpassword.js
+++ b/static/js/resetpassword.js
@@ -1,6 +1,10 @@
 const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'http://dialogai.duckdns.org:8080';
-const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'http://dialogai.duckdns.org:8000';
+
+// [수정] HTTPS 적용 - Caddy가 프록시하므로 포트 번호 제거
+// const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.duckdns.org';
+// const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.duckdns.org';
+const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.ddns.net';
+const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.ddns.net';
 
 function getTokenFromUrl() {
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## 📋 요약
Google 캘린더 미연동 사용자를 위한 안내 UI 추가 및 도메인/HTTPS 설정을 수정했습니다.

## 🔧 주요 변경사항

### 1️⃣ Google 캘린더 연동 안내 UI (`static/js/home.js`)
- ✅ 캘린더 미연동 시 안내 메시지 표시
- ✅ "Google 계정 연동하기" 버튼 추가
- ✅ 연동 완료 후 캘린더 이벤트 정상 표시

### 2️⃣ API URL 설정 수정 (`static/js/app.js`, `static/js/resetpassword.js`)
- ✅ 도메인 변경: `dialogai.duckdns.org` → `dialogai.ddns.net`
- ✅ HTTPS 적용: `http://` → `https://`
- ✅ 포트 번호 제거 (Caddy 리버스 프록시 사용)

### 3️⃣ 불필요한 스크립트 제거 (`meetings.html`)
- ✅ `chatbot.js` 스크립트 참조 제거