### PR TITLE
release: [FE] v1.3.0 - Google 캘린더 연동 안내 및 HTTPS/도메인 설정

### DIFF
--- a/meetings.html
+++ b/meetings.html
@@ -185,7 +185,6 @@
   <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
   <script src="/static/js/app.js"></script>
   <script src="/static/js/meetings.js"></script>
-  <script src="/static/js/chatbot.js"></script>
 </body>
 
 </html>

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,6 +1,10 @@
 const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'http://dialogai.duckdns.org:8080';
-const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'http://dialogai.duckdns.org:8000';
+
+// [수정] HTTPS 적용 - Caddy가 프록시하므로 포트 번호 제거
+// const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.duckdns.org';
+// const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.duckdns.org';
+const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.ddns.net';
+const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.ddns.net';
 
 // ============================================================
 // API URL 설정

--- a/static/js/resetpassword.js
+++ b/static/js/resetpassword.js
@@ -1,6 +1,10 @@
 const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
-const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'http://dialogai.duckdns.org:8080';
-const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'http://dialogai.duckdns.org:8000';
+
+// [수정] HTTPS 적용 - Caddy가 프록시하므로 포트 번호 제거
+// const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.duckdns.org';
+// const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.duckdns.org';
+const BACKEND_BASE_URL = isLocal ? 'http://localhost:8080' : 'https://dialogai.ddns.net';
+const AI_BASE_URL = isLocal ? 'http://localhost:8000' : 'https://dialogai.ddns.net';
 
 function getTokenFromUrl() {
     const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## 🚀 릴리즈 노트 v1.3.0

### 새로운 기능
- ✨ Google 캘린더 미연동 사용자를 위한 안내 UI 추가
- ✨ "Google 계정 연동하기" 버튼 추가

### 버그 수정
- 🐛 도메인 변경 미반영 문제 해결 (duckdns → ddns.net)
- 🐛 HTTPS 미적용 문제 해결
- 🐛 불필요한 chatbot.js 스크립트 참조 제거

### 개선 사항
- ⚡ API URL HTTPS 적용
- ⚡ Caddy 리버스 프록시 환경에 맞게 포트 번호 제거
- ⚡ 캘린더 연동 상태에 따른 UI 분기 처리

### 기술 스택
- Vanilla JavaScript 프론트엔드
- Caddy 리버스 프록시
- AWS EC2 운영 환경

### 배포 정보
- 배포 환경: EC2 (https://dialogai.ddns.net)
- 배포 방법: GitHub Actions CI/CD 파이프라인
- Docker 이미지: munwalk/dialog-frontend:latest